### PR TITLE
Prepublish is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "./protocol/typescript/dist/all_generated.d.ts",
   "scripts": {
     "build": "npx tsc",
-    "prepublish": "npm run build"
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
just a small fix
More info about this [in here](https://docs.npmjs.com/cli/v9/using-npm/scripts#prepare-and-prepublish)