### PR TITLE
Bring back elbow offset

### DIFF
--- a/protocol/cpp/include/solarxr_protocol/generated/all_generated.h
+++ b/protocol/cpp/include/solarxr_protocol/generated/all_generated.h
@@ -1019,11 +1019,12 @@ enum class SkeletonBone : uint8_t {
   LOWER_ARM = 17,
   CONTROLLER_Y = 18,
   CONTROLLER_Z = 19,
+  ELBOW_OFFSET = 20,
   MIN = NONE,
-  MAX = CONTROLLER_Z
+  MAX = ELBOW_OFFSET
 };
 
-inline const SkeletonBone (&EnumValuesSkeletonBone())[20] {
+inline const SkeletonBone (&EnumValuesSkeletonBone())[21] {
   static const SkeletonBone values[] = {
     SkeletonBone::NONE,
     SkeletonBone::HEAD,
@@ -1044,13 +1045,14 @@ inline const SkeletonBone (&EnumValuesSkeletonBone())[20] {
     SkeletonBone::UPPER_ARM,
     SkeletonBone::LOWER_ARM,
     SkeletonBone::CONTROLLER_Y,
-    SkeletonBone::CONTROLLER_Z
+    SkeletonBone::CONTROLLER_Z,
+    SkeletonBone::ELBOW_OFFSET
   };
   return values;
 }
 
 inline const char * const *EnumNamesSkeletonBone() {
-  static const char * const names[21] = {
+  static const char * const names[22] = {
     "NONE",
     "HEAD",
     "NECK",
@@ -1071,13 +1073,14 @@ inline const char * const *EnumNamesSkeletonBone() {
     "LOWER_ARM",
     "CONTROLLER_Y",
     "CONTROLLER_Z",
+    "ELBOW_OFFSET",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameSkeletonBone(SkeletonBone e) {
-  if (flatbuffers::IsOutRange(e, SkeletonBone::NONE, SkeletonBone::CONTROLLER_Z)) return "";
+  if (flatbuffers::IsOutRange(e, SkeletonBone::NONE, SkeletonBone::ELBOW_OFFSET)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesSkeletonBone()[index];
 }

--- a/protocol/java/src/solarxr_protocol/rpc/SkeletonBone.java
+++ b/protocol/java/src/solarxr_protocol/rpc/SkeletonBone.java
@@ -25,8 +25,9 @@ public final class SkeletonBone {
   public static final int LOWER_ARM = 17;
   public static final int CONTROLLER_Y = 18;
   public static final int CONTROLLER_Z = 19;
+  public static final int ELBOW_OFFSET = 20;
 
-  public static final String[] names = { "NONE", "HEAD", "NECK", "CHEST", "CHEST_OFFSET", "WAIST", "HIP", "HIP_OFFSET", "HIPS_WIDTH", "UPPER_LEG", "LOWER_LEG", "FOOT_LENGTH", "FOOT_SHIFT", "SKELETON_OFFSET", "SHOULDERS_DISTANCE", "SHOULDERS_WIDTH", "UPPER_ARM", "LOWER_ARM", "CONTROLLER_Y", "CONTROLLER_Z", };
+  public static final String[] names = { "NONE", "HEAD", "NECK", "CHEST", "CHEST_OFFSET", "WAIST", "HIP", "HIP_OFFSET", "HIPS_WIDTH", "UPPER_LEG", "LOWER_LEG", "FOOT_LENGTH", "FOOT_SHIFT", "SKELETON_OFFSET", "SHOULDERS_DISTANCE", "SHOULDERS_WIDTH", "UPPER_ARM", "LOWER_ARM", "CONTROLLER_Y", "CONTROLLER_Z", "ELBOW_OFFSET", };
 
   public static String name(int e) { return names[e]; }
 }

--- a/protocol/rust/src/generated/solarxr_protocol/rpc/skeleton_bone_generated.rs
+++ b/protocol/rust/src/generated/solarxr_protocol/rpc/skeleton_bone_generated.rs
@@ -12,10 +12,10 @@ use super::*;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 pub const ENUM_MIN_SKELETON_BONE: u8 = 0;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
-pub const ENUM_MAX_SKELETON_BONE: u8 = 19;
+pub const ENUM_MAX_SKELETON_BONE: u8 = 20;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_SKELETON_BONE: [SkeletonBone; 20] = [
+pub const ENUM_VALUES_SKELETON_BONE: [SkeletonBone; 21] = [
   SkeletonBone::NONE,
   SkeletonBone::HEAD,
   SkeletonBone::NECK,
@@ -36,6 +36,7 @@ pub const ENUM_VALUES_SKELETON_BONE: [SkeletonBone; 20] = [
   SkeletonBone::LOWER_ARM,
   SkeletonBone::CONTROLLER_Y,
   SkeletonBone::CONTROLLER_Z,
+  SkeletonBone::ELBOW_OFFSET,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -63,9 +64,10 @@ impl SkeletonBone {
   pub const LOWER_ARM: Self = Self(17);
   pub const CONTROLLER_Y: Self = Self(18);
   pub const CONTROLLER_Z: Self = Self(19);
+  pub const ELBOW_OFFSET: Self = Self(20);
 
   pub const ENUM_MIN: u8 = 0;
-  pub const ENUM_MAX: u8 = 19;
+  pub const ENUM_MAX: u8 = 20;
   pub const ENUM_VALUES: &'static [Self] = &[
     Self::NONE,
     Self::HEAD,
@@ -87,6 +89,7 @@ impl SkeletonBone {
     Self::LOWER_ARM,
     Self::CONTROLLER_Y,
     Self::CONTROLLER_Z,
+    Self::ELBOW_OFFSET,
   ];
   /// Returns the variant's name or "" if unknown.
   pub fn variant_name(self) -> Option<&'static str> {
@@ -111,6 +114,7 @@ impl SkeletonBone {
       Self::LOWER_ARM => Some("LOWER_ARM"),
       Self::CONTROLLER_Y => Some("CONTROLLER_Y"),
       Self::CONTROLLER_Z => Some("CONTROLLER_Z"),
+      Self::ELBOW_OFFSET => Some("ELBOW_OFFSET"),
       _ => None,
     }
   }

--- a/protocol/typescript/src/solarxr-protocol/rpc/skeleton-bone.ts
+++ b/protocol/typescript/src/solarxr-protocol/rpc/skeleton-bone.ts
@@ -20,5 +20,6 @@ export enum SkeletonBone {
   UPPER_ARM = 16,
   LOWER_ARM = 17,
   CONTROLLER_Y = 18,
-  CONTROLLER_Z = 19
+  CONTROLLER_Z = 19,
+  ELBOW_OFFSET = 20
 }

--- a/schema/rpc.fbs
+++ b/schema/rpc.fbs
@@ -197,6 +197,7 @@ enum SkeletonBone: uint8 {
     LOWER_ARM = 17,
     CONTROLLER_Y = 18,
     CONTROLLER_Z = 19,
+    ELBOW_OFFSET = 20,
 }
 
 table SkeletonPart {


### PR DESCRIPTION
I remove the elbow offset in https://github.com/SlimeVR/SolarXR-Protocol/pull/86, but I forgot it was actually used for better shoulder tracking from controllers, and now, to compensate for VRChat's calibration mapping the elbows to the chest.
