### PR TITLE
Fix portin/out snake case

### DIFF
--- a/protocol/cpp/include/solarxr_protocol/generated/all_generated.h
+++ b/protocol/cpp/include/solarxr_protocol/generated/all_generated.h
@@ -4670,18 +4670,18 @@ struct OSCSettings FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef OSCSettingsBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ENABLED = 4,
-    VT_PORTIN = 6,
-    VT_PORTOUT = 8,
+    VT_PORT_IN = 6,
+    VT_PORT_OUT = 8,
     VT_ADDRESS = 10
   };
   bool enabled() const {
     return GetField<uint8_t>(VT_ENABLED, 0) != 0;
   }
-  uint16_t portIn() const {
-    return GetField<uint16_t>(VT_PORTIN, 0);
+  uint16_t port_in() const {
+    return GetField<uint16_t>(VT_PORT_IN, 0);
   }
-  uint16_t portOut() const {
-    return GetField<uint16_t>(VT_PORTOUT, 0);
+  uint16_t port_out() const {
+    return GetField<uint16_t>(VT_PORT_OUT, 0);
   }
   const flatbuffers::String *address() const {
     return GetPointer<const flatbuffers::String *>(VT_ADDRESS);
@@ -4689,8 +4689,8 @@ struct OSCSettings FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<uint8_t>(verifier, VT_ENABLED, 1) &&
-           VerifyField<uint16_t>(verifier, VT_PORTIN, 2) &&
-           VerifyField<uint16_t>(verifier, VT_PORTOUT, 2) &&
+           VerifyField<uint16_t>(verifier, VT_PORT_IN, 2) &&
+           VerifyField<uint16_t>(verifier, VT_PORT_OUT, 2) &&
            VerifyOffset(verifier, VT_ADDRESS) &&
            verifier.VerifyString(address()) &&
            verifier.EndTable();
@@ -4704,11 +4704,11 @@ struct OSCSettingsBuilder {
   void add_enabled(bool enabled) {
     fbb_.AddElement<uint8_t>(OSCSettings::VT_ENABLED, static_cast<uint8_t>(enabled), 0);
   }
-  void add_portIn(uint16_t portIn) {
-    fbb_.AddElement<uint16_t>(OSCSettings::VT_PORTIN, portIn, 0);
+  void add_port_in(uint16_t port_in) {
+    fbb_.AddElement<uint16_t>(OSCSettings::VT_PORT_IN, port_in, 0);
   }
-  void add_portOut(uint16_t portOut) {
-    fbb_.AddElement<uint16_t>(OSCSettings::VT_PORTOUT, portOut, 0);
+  void add_port_out(uint16_t port_out) {
+    fbb_.AddElement<uint16_t>(OSCSettings::VT_PORT_OUT, port_out, 0);
   }
   void add_address(flatbuffers::Offset<flatbuffers::String> address) {
     fbb_.AddOffset(OSCSettings::VT_ADDRESS, address);
@@ -4727,13 +4727,13 @@ struct OSCSettingsBuilder {
 inline flatbuffers::Offset<OSCSettings> CreateOSCSettings(
     flatbuffers::FlatBufferBuilder &_fbb,
     bool enabled = false,
-    uint16_t portIn = 0,
-    uint16_t portOut = 0,
+    uint16_t port_in = 0,
+    uint16_t port_out = 0,
     flatbuffers::Offset<flatbuffers::String> address = 0) {
   OSCSettingsBuilder builder_(_fbb);
   builder_.add_address(address);
-  builder_.add_portOut(portOut);
-  builder_.add_portIn(portIn);
+  builder_.add_port_out(port_out);
+  builder_.add_port_in(port_in);
   builder_.add_enabled(enabled);
   return builder_.Finish();
 }
@@ -4741,15 +4741,15 @@ inline flatbuffers::Offset<OSCSettings> CreateOSCSettings(
 inline flatbuffers::Offset<OSCSettings> CreateOSCSettingsDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     bool enabled = false,
-    uint16_t portIn = 0,
-    uint16_t portOut = 0,
+    uint16_t port_in = 0,
+    uint16_t port_out = 0,
     const char *address = nullptr) {
   auto address__ = address ? _fbb.CreateString(address) : 0;
   return solarxr_protocol::rpc::CreateOSCSettings(
       _fbb,
       enabled,
-      portIn,
-      portOut,
+      port_in,
+      port_out,
       address__);
 }
 

--- a/protocol/rust/src/generated/solarxr_protocol/rpc/oscsettings_generated.rs
+++ b/protocol/rust/src/generated/solarxr_protocol/rpc/oscsettings_generated.rs
@@ -27,8 +27,8 @@ impl<'a> flatbuffers::Follow<'a> for OSCSettings<'a> {
 
 impl<'a> OSCSettings<'a> {
   pub const VT_ENABLED: flatbuffers::VOffsetT = 4;
-  pub const VT_PORTIN: flatbuffers::VOffsetT = 6;
-  pub const VT_PORTOUT: flatbuffers::VOffsetT = 8;
+  pub const VT_PORT_IN: flatbuffers::VOffsetT = 6;
+  pub const VT_PORT_OUT: flatbuffers::VOffsetT = 8;
   pub const VT_ADDRESS: flatbuffers::VOffsetT = 10;
 
   #[inline]
@@ -42,8 +42,8 @@ impl<'a> OSCSettings<'a> {
   ) -> flatbuffers::WIPOffset<OSCSettings<'bldr>> {
     let mut builder = OSCSettingsBuilder::new(_fbb);
     if let Some(x) = args.address { builder.add_address(x); }
-    builder.add_portOut(args.portOut);
-    builder.add_portIn(args.portIn);
+    builder.add_port_out(args.port_out);
+    builder.add_port_in(args.port_in);
     builder.add_enabled(args.enabled);
     builder.finish()
   }
@@ -57,18 +57,18 @@ impl<'a> OSCSettings<'a> {
     unsafe { self._tab.get::<bool>(OSCSettings::VT_ENABLED, Some(false)).unwrap()}
   }
   #[inline]
-  pub fn portIn(&self) -> u16 {
+  pub fn port_in(&self) -> u16 {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<u16>(OSCSettings::VT_PORTIN, Some(0)).unwrap()}
+    unsafe { self._tab.get::<u16>(OSCSettings::VT_PORT_IN, Some(0)).unwrap()}
   }
   #[inline]
-  pub fn portOut(&self) -> u16 {
+  pub fn port_out(&self) -> u16 {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<u16>(OSCSettings::VT_PORTOUT, Some(0)).unwrap()}
+    unsafe { self._tab.get::<u16>(OSCSettings::VT_PORT_OUT, Some(0)).unwrap()}
   }
   #[inline]
   pub fn address(&self) -> Option<&'a str> {
@@ -87,8 +87,8 @@ impl flatbuffers::Verifiable for OSCSettings<'_> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
      .visit_field::<bool>("enabled", Self::VT_ENABLED, false)?
-     .visit_field::<u16>("portIn", Self::VT_PORTIN, false)?
-     .visit_field::<u16>("portOut", Self::VT_PORTOUT, false)?
+     .visit_field::<u16>("port_in", Self::VT_PORT_IN, false)?
+     .visit_field::<u16>("port_out", Self::VT_PORT_OUT, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<&str>>("address", Self::VT_ADDRESS, false)?
      .finish();
     Ok(())
@@ -96,8 +96,8 @@ impl flatbuffers::Verifiable for OSCSettings<'_> {
 }
 pub struct OSCSettingsArgs<'a> {
     pub enabled: bool,
-    pub portIn: u16,
-    pub portOut: u16,
+    pub port_in: u16,
+    pub port_out: u16,
     pub address: Option<flatbuffers::WIPOffset<&'a str>>,
 }
 impl<'a> Default for OSCSettingsArgs<'a> {
@@ -105,8 +105,8 @@ impl<'a> Default for OSCSettingsArgs<'a> {
   fn default() -> Self {
     OSCSettingsArgs {
       enabled: false,
-      portIn: 0,
-      portOut: 0,
+      port_in: 0,
+      port_out: 0,
       address: None,
     }
   }
@@ -122,12 +122,12 @@ impl<'a: 'b, 'b> OSCSettingsBuilder<'a, 'b> {
     self.fbb_.push_slot::<bool>(OSCSettings::VT_ENABLED, enabled, false);
   }
   #[inline]
-  pub fn add_portIn(&mut self, portIn: u16) {
-    self.fbb_.push_slot::<u16>(OSCSettings::VT_PORTIN, portIn, 0);
+  pub fn add_port_in(&mut self, port_in: u16) {
+    self.fbb_.push_slot::<u16>(OSCSettings::VT_PORT_IN, port_in, 0);
   }
   #[inline]
-  pub fn add_portOut(&mut self, portOut: u16) {
-    self.fbb_.push_slot::<u16>(OSCSettings::VT_PORTOUT, portOut, 0);
+  pub fn add_port_out(&mut self, port_out: u16) {
+    self.fbb_.push_slot::<u16>(OSCSettings::VT_PORT_OUT, port_out, 0);
   }
   #[inline]
   pub fn add_address(&mut self, address: flatbuffers::WIPOffset<&'b  str>) {
@@ -152,8 +152,8 @@ impl core::fmt::Debug for OSCSettings<'_> {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
     let mut ds = f.debug_struct("OSCSettings");
       ds.field("enabled", &self.enabled());
-      ds.field("portIn", &self.portIn());
-      ds.field("portOut", &self.portOut());
+      ds.field("port_in", &self.port_in());
+      ds.field("port_out", &self.port_out());
       ds.field("address", &self.address());
       ds.finish()
   }

--- a/schema/rpc.fbs
+++ b/schema/rpc.fbs
@@ -147,8 +147,8 @@ table VRCOSCSettings {
 /// OSC Settings that are used in *any* osc application.
 table OSCSettings {
     enabled: bool;
-    portIn: uint16;
-    portOut: uint16;
+    port_in: uint16;
+    port_out: uint16;
     address: string;
 }
 


### PR DESCRIPTION
I think Uriel wanted to fix this or something, but they never did and I noticed it again, so here.
No server changes are needed, as generated convert snake cases to camel for Java and tsx