### PR TITLE
Move TPS field into TrackerData

### DIFF
--- a/protocol/cpp/include/solarxr_protocol/generated/all_generated.h
+++ b/protocol/cpp/include/solarxr_protocol/generated/all_generated.h
@@ -2030,7 +2030,6 @@ struct HardwareStatus FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef HardwareStatusBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ERROR_STATUS = 4,
-    VT_TPS = 6,
     VT_PING = 8,
     VT_RSSI = 10,
     VT_MCU_TEMP = 12,
@@ -2040,9 +2039,6 @@ struct HardwareStatus FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   };
   flatbuffers::Optional<solarxr_protocol::datatypes::FirmwareErrorCode> error_status() const {
     return GetOptional<uint8_t, solarxr_protocol::datatypes::FirmwareErrorCode>(VT_ERROR_STATUS);
-  }
-  flatbuffers::Optional<uint8_t> tps() const {
-    return GetOptional<uint8_t, uint8_t>(VT_TPS);
   }
   flatbuffers::Optional<uint16_t> ping() const {
     return GetOptional<uint16_t, uint16_t>(VT_PING);
@@ -2067,7 +2063,6 @@ struct HardwareStatus FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<uint8_t>(verifier, VT_ERROR_STATUS, 1) &&
-           VerifyField<uint8_t>(verifier, VT_TPS, 1) &&
            VerifyField<uint16_t>(verifier, VT_PING, 2) &&
            VerifyField<int16_t>(verifier, VT_RSSI, 2) &&
            VerifyField<float>(verifier, VT_MCU_TEMP, 4) &&
@@ -2085,9 +2080,6 @@ struct HardwareStatusBuilder {
   flatbuffers::uoffset_t start_;
   void add_error_status(solarxr_protocol::datatypes::FirmwareErrorCode error_status) {
     fbb_.AddElement<uint8_t>(HardwareStatus::VT_ERROR_STATUS, static_cast<uint8_t>(error_status));
-  }
-  void add_tps(uint8_t tps) {
-    fbb_.AddElement<uint8_t>(HardwareStatus::VT_TPS, tps);
   }
   void add_ping(uint16_t ping) {
     fbb_.AddElement<uint16_t>(HardwareStatus::VT_PING, ping);
@@ -2121,7 +2113,6 @@ struct HardwareStatusBuilder {
 inline flatbuffers::Offset<HardwareStatus> CreateHardwareStatus(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Optional<solarxr_protocol::datatypes::FirmwareErrorCode> error_status = flatbuffers::nullopt,
-    flatbuffers::Optional<uint8_t> tps = flatbuffers::nullopt,
     flatbuffers::Optional<uint16_t> ping = flatbuffers::nullopt,
     flatbuffers::Optional<int16_t> rssi = flatbuffers::nullopt,
     flatbuffers::Optional<float> mcu_temp = flatbuffers::nullopt,
@@ -2135,7 +2126,6 @@ inline flatbuffers::Offset<HardwareStatus> CreateHardwareStatus(
   if(rssi) { builder_.add_rssi(*rssi); }
   if(ping) { builder_.add_ping(*ping); }
   if(battery_pct_estimate) { builder_.add_battery_pct_estimate(*battery_pct_estimate); }
-  if(tps) { builder_.add_tps(*tps); }
   if(error_status) { builder_.add_error_status(*error_status); }
   return builder_.Finish();
 }
@@ -2266,7 +2256,8 @@ struct TrackerData FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_TEMP = 18,
     VT_LINEAR_ACCELERATION = 20,
     VT_ROTATION_REFERENCE_ADJUSTED = 22,
-    VT_ROTATION_IDENTITY_ADJUSTED = 24
+    VT_ROTATION_IDENTITY_ADJUSTED = 24,
+    VT_TPS = 26
   };
   const solarxr_protocol::datatypes::TrackerId *tracker_id() const {
     return GetPointer<const solarxr_protocol::datatypes::TrackerId *>(VT_TRACKER_ID);
@@ -2319,6 +2310,10 @@ struct TrackerData FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const solarxr_protocol::datatypes::math::Quat *rotation_identity_adjusted() const {
     return GetStruct<const solarxr_protocol::datatypes::math::Quat *>(VT_ROTATION_IDENTITY_ADJUSTED);
   }
+  /// Data ticks per second, processed by SlimeVR server
+  flatbuffers::Optional<uint16_t> tps() const {
+    return GetOptional<uint16_t, uint16_t>(VT_TPS);
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_TRACKER_ID) &&
@@ -2334,6 +2329,7 @@ struct TrackerData FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyField<solarxr_protocol::datatypes::math::Vec3f>(verifier, VT_LINEAR_ACCELERATION, 4) &&
            VerifyField<solarxr_protocol::datatypes::math::Quat>(verifier, VT_ROTATION_REFERENCE_ADJUSTED, 4) &&
            VerifyField<solarxr_protocol::datatypes::math::Quat>(verifier, VT_ROTATION_IDENTITY_ADJUSTED, 4) &&
+           VerifyField<uint16_t>(verifier, VT_TPS, 2) &&
            verifier.EndTable();
   }
 };
@@ -2375,6 +2371,9 @@ struct TrackerDataBuilder {
   void add_rotation_identity_adjusted(const solarxr_protocol::datatypes::math::Quat *rotation_identity_adjusted) {
     fbb_.AddStruct(TrackerData::VT_ROTATION_IDENTITY_ADJUSTED, rotation_identity_adjusted);
   }
+  void add_tps(uint16_t tps) {
+    fbb_.AddElement<uint16_t>(TrackerData::VT_TPS, tps);
+  }
   explicit TrackerDataBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -2398,7 +2397,8 @@ inline flatbuffers::Offset<TrackerData> CreateTrackerData(
     const solarxr_protocol::datatypes::Temperature *temp = nullptr,
     const solarxr_protocol::datatypes::math::Vec3f *linear_acceleration = nullptr,
     const solarxr_protocol::datatypes::math::Quat *rotation_reference_adjusted = nullptr,
-    const solarxr_protocol::datatypes::math::Quat *rotation_identity_adjusted = nullptr) {
+    const solarxr_protocol::datatypes::math::Quat *rotation_identity_adjusted = nullptr,
+    flatbuffers::Optional<uint16_t> tps = flatbuffers::nullopt) {
   TrackerDataBuilder builder_(_fbb);
   builder_.add_rotation_identity_adjusted(rotation_identity_adjusted);
   builder_.add_rotation_reference_adjusted(rotation_reference_adjusted);
@@ -2410,6 +2410,7 @@ inline flatbuffers::Offset<TrackerData> CreateTrackerData(
   builder_.add_rotation(rotation);
   builder_.add_info(info);
   builder_.add_tracker_id(tracker_id);
+  if(tps) { builder_.add_tps(*tps); }
   builder_.add_status(status);
   return builder_.Finish();
 }
@@ -2427,7 +2428,8 @@ struct TrackerDataMask FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_TEMP = 16,
     VT_LINEAR_ACCELERATION = 18,
     VT_ROTATION_REFERENCE_ADJUSTED = 20,
-    VT_ROTATION_IDENTITY_ADJUSTED = 22
+    VT_ROTATION_IDENTITY_ADJUSTED = 22,
+    VT_TPS = 24
   };
   bool info() const {
     return GetField<uint8_t>(VT_INFO, 0) != 0;
@@ -2459,6 +2461,9 @@ struct TrackerDataMask FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool rotation_identity_adjusted() const {
     return GetField<uint8_t>(VT_ROTATION_IDENTITY_ADJUSTED, 0) != 0;
   }
+  bool tps() const {
+    return GetField<uint8_t>(VT_TPS, 0) != 0;
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<uint8_t>(verifier, VT_INFO, 1) &&
@@ -2471,6 +2476,7 @@ struct TrackerDataMask FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyField<uint8_t>(verifier, VT_LINEAR_ACCELERATION, 1) &&
            VerifyField<uint8_t>(verifier, VT_ROTATION_REFERENCE_ADJUSTED, 1) &&
            VerifyField<uint8_t>(verifier, VT_ROTATION_IDENTITY_ADJUSTED, 1) &&
+           VerifyField<uint8_t>(verifier, VT_TPS, 1) &&
            verifier.EndTable();
   }
 };
@@ -2509,6 +2515,9 @@ struct TrackerDataMaskBuilder {
   void add_rotation_identity_adjusted(bool rotation_identity_adjusted) {
     fbb_.AddElement<uint8_t>(TrackerDataMask::VT_ROTATION_IDENTITY_ADJUSTED, static_cast<uint8_t>(rotation_identity_adjusted), 0);
   }
+  void add_tps(bool tps) {
+    fbb_.AddElement<uint8_t>(TrackerDataMask::VT_TPS, static_cast<uint8_t>(tps), 0);
+  }
   explicit TrackerDataMaskBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -2531,8 +2540,10 @@ inline flatbuffers::Offset<TrackerDataMask> CreateTrackerDataMask(
     bool temp = false,
     bool linear_acceleration = false,
     bool rotation_reference_adjusted = false,
-    bool rotation_identity_adjusted = false) {
+    bool rotation_identity_adjusted = false,
+    bool tps = false) {
   TrackerDataMaskBuilder builder_(_fbb);
+  builder_.add_tps(tps);
   builder_.add_rotation_identity_adjusted(rotation_identity_adjusted);
   builder_.add_rotation_reference_adjusted(rotation_reference_adjusted);
   builder_.add_linear_acceleration(linear_acceleration);

--- a/protocol/java/src/solarxr_protocol/data_feed/tracker/TrackerData.java
+++ b/protocol/java/src/solarxr_protocol/data_feed/tracker/TrackerData.java
@@ -77,8 +77,13 @@ public final class TrackerData extends Table {
    */
   public solarxr_protocol.datatypes.math.Quat rotationIdentityAdjusted() { return rotationIdentityAdjusted(new solarxr_protocol.datatypes.math.Quat()); }
   public solarxr_protocol.datatypes.math.Quat rotationIdentityAdjusted(solarxr_protocol.datatypes.math.Quat obj) { int o = __offset(24); return o != 0 ? obj.__assign(o + bb_pos, bb) : null; }
+  /**
+   * Data ticks per second, processed by SlimeVR server
+   */
+  public boolean hasTps() { return 0 != __offset(26); }
+  public int tps() { int o = __offset(26); return o != 0 ? bb.getShort(o + bb_pos) & 0xFFFF : 0; }
 
-  public static void startTrackerData(FlatBufferBuilder builder) { builder.startTable(11); }
+  public static void startTrackerData(FlatBufferBuilder builder) { builder.startTable(12); }
   public static void addTrackerId(FlatBufferBuilder builder, int trackerIdOffset) { builder.addOffset(0, trackerIdOffset, 0); }
   public static void addInfo(FlatBufferBuilder builder, int infoOffset) { builder.addOffset(1, infoOffset, 0); }
   public static void addStatus(FlatBufferBuilder builder, int status) { builder.addByte(2, (byte) status, (byte) 0); }
@@ -90,6 +95,7 @@ public final class TrackerData extends Table {
   public static void addLinearAcceleration(FlatBufferBuilder builder, int linearAccelerationOffset) { builder.addStruct(8, linearAccelerationOffset, 0); }
   public static void addRotationReferenceAdjusted(FlatBufferBuilder builder, int rotationReferenceAdjustedOffset) { builder.addStruct(9, rotationReferenceAdjustedOffset, 0); }
   public static void addRotationIdentityAdjusted(FlatBufferBuilder builder, int rotationIdentityAdjustedOffset) { builder.addStruct(10, rotationIdentityAdjustedOffset, 0); }
+  public static void addTps(FlatBufferBuilder builder, int tps) { builder.addShort(11, (short) tps, (short) 0); }
   public static int endTrackerData(FlatBufferBuilder builder) {
     int o = builder.endTable();
     return o;
@@ -129,6 +135,8 @@ public final class TrackerData extends Table {
     else _o.setRotationReferenceAdjusted(null);
     if (rotationIdentityAdjusted() != null) rotationIdentityAdjusted().unpackTo(_o.getRotationIdentityAdjusted());
     else _o.setRotationIdentityAdjusted(null);
+    Integer _oTps = hasTps() ? tps() : null;
+    _o.setTps(_oTps);
   }
   public static int pack(FlatBufferBuilder builder, TrackerDataT _o) {
     if (_o == null) return 0;
@@ -146,6 +154,7 @@ public final class TrackerData extends Table {
     addLinearAcceleration(builder, solarxr_protocol.datatypes.math.Vec3f.pack(builder, _o.getLinearAcceleration()));
     addRotationReferenceAdjusted(builder, solarxr_protocol.datatypes.math.Quat.pack(builder, _o.getRotationReferenceAdjusted()));
     addRotationIdentityAdjusted(builder, solarxr_protocol.datatypes.math.Quat.pack(builder, _o.getRotationIdentityAdjusted()));
+    if (_o.getTps() != null) { addTps(builder, _o.getTps()); }
     return endTrackerData(builder);
   }
 }

--- a/protocol/java/src/solarxr_protocol/data_feed/tracker/TrackerDataMask.java
+++ b/protocol/java/src/solarxr_protocol/data_feed/tracker/TrackerDataMask.java
@@ -28,6 +28,7 @@ public final class TrackerDataMask extends Table {
   public boolean linearAcceleration() { int o = __offset(18); return o != 0 ? 0!=bb.get(o + bb_pos) : false; }
   public boolean rotationReferenceAdjusted() { int o = __offset(20); return o != 0 ? 0!=bb.get(o + bb_pos) : false; }
   public boolean rotationIdentityAdjusted() { int o = __offset(22); return o != 0 ? 0!=bb.get(o + bb_pos) : false; }
+  public boolean tps() { int o = __offset(24); return o != 0 ? 0!=bb.get(o + bb_pos) : false; }
 
   public static int createTrackerDataMask(FlatBufferBuilder builder,
       boolean info,
@@ -39,8 +40,10 @@ public final class TrackerDataMask extends Table {
       boolean temp,
       boolean linearAcceleration,
       boolean rotationReferenceAdjusted,
-      boolean rotationIdentityAdjusted) {
-    builder.startTable(10);
+      boolean rotationIdentityAdjusted,
+      boolean tps) {
+    builder.startTable(11);
+    TrackerDataMask.addTps(builder, tps);
     TrackerDataMask.addRotationIdentityAdjusted(builder, rotationIdentityAdjusted);
     TrackerDataMask.addRotationReferenceAdjusted(builder, rotationReferenceAdjusted);
     TrackerDataMask.addLinearAcceleration(builder, linearAcceleration);
@@ -54,7 +57,7 @@ public final class TrackerDataMask extends Table {
     return TrackerDataMask.endTrackerDataMask(builder);
   }
 
-  public static void startTrackerDataMask(FlatBufferBuilder builder) { builder.startTable(10); }
+  public static void startTrackerDataMask(FlatBufferBuilder builder) { builder.startTable(11); }
   public static void addInfo(FlatBufferBuilder builder, boolean info) { builder.addBoolean(0, info, false); }
   public static void addStatus(FlatBufferBuilder builder, boolean status) { builder.addBoolean(1, status, false); }
   public static void addRotation(FlatBufferBuilder builder, boolean rotation) { builder.addBoolean(2, rotation, false); }
@@ -65,6 +68,7 @@ public final class TrackerDataMask extends Table {
   public static void addLinearAcceleration(FlatBufferBuilder builder, boolean linearAcceleration) { builder.addBoolean(7, linearAcceleration, false); }
   public static void addRotationReferenceAdjusted(FlatBufferBuilder builder, boolean rotationReferenceAdjusted) { builder.addBoolean(8, rotationReferenceAdjusted, false); }
   public static void addRotationIdentityAdjusted(FlatBufferBuilder builder, boolean rotationIdentityAdjusted) { builder.addBoolean(9, rotationIdentityAdjusted, false); }
+  public static void addTps(FlatBufferBuilder builder, boolean tps) { builder.addBoolean(10, tps, false); }
   public static int endTrackerDataMask(FlatBufferBuilder builder) {
     int o = builder.endTable();
     return o;
@@ -102,6 +106,8 @@ public final class TrackerDataMask extends Table {
     _o.setRotationReferenceAdjusted(_oRotationReferenceAdjusted);
     boolean _oRotationIdentityAdjusted = rotationIdentityAdjusted();
     _o.setRotationIdentityAdjusted(_oRotationIdentityAdjusted);
+    boolean _oTps = tps();
+    _o.setTps(_oTps);
   }
   public static int pack(FlatBufferBuilder builder, TrackerDataMaskT _o) {
     if (_o == null) return 0;
@@ -116,7 +122,8 @@ public final class TrackerDataMask extends Table {
       _o.getTemp(),
       _o.getLinearAcceleration(),
       _o.getRotationReferenceAdjusted(),
-      _o.getRotationIdentityAdjusted());
+      _o.getRotationIdentityAdjusted(),
+      _o.getTps());
   }
 }
 

--- a/protocol/java/src/solarxr_protocol/data_feed/tracker/TrackerDataMaskT.java
+++ b/protocol/java/src/solarxr_protocol/data_feed/tracker/TrackerDataMaskT.java
@@ -18,6 +18,7 @@ public class TrackerDataMaskT {
   private boolean linearAcceleration;
   private boolean rotationReferenceAdjusted;
   private boolean rotationIdentityAdjusted;
+  private boolean tps;
 
   public boolean getInfo() { return info; }
 
@@ -59,6 +60,10 @@ public class TrackerDataMaskT {
 
   public void setRotationIdentityAdjusted(boolean rotationIdentityAdjusted) { this.rotationIdentityAdjusted = rotationIdentityAdjusted; }
 
+  public boolean getTps() { return tps; }
+
+  public void setTps(boolean tps) { this.tps = tps; }
+
 
   public TrackerDataMaskT() {
     this.info = false;
@@ -71,6 +76,7 @@ public class TrackerDataMaskT {
     this.linearAcceleration = false;
     this.rotationReferenceAdjusted = false;
     this.rotationIdentityAdjusted = false;
+    this.tps = false;
   }
 }
 

--- a/protocol/java/src/solarxr_protocol/data_feed/tracker/TrackerDataT.java
+++ b/protocol/java/src/solarxr_protocol/data_feed/tracker/TrackerDataT.java
@@ -19,6 +19,7 @@ public class TrackerDataT {
   private solarxr_protocol.datatypes.math.Vec3fT linearAcceleration;
   private solarxr_protocol.datatypes.math.QuatT rotationReferenceAdjusted;
   private solarxr_protocol.datatypes.math.QuatT rotationIdentityAdjusted;
+  private Integer tps;
 
   public solarxr_protocol.datatypes.TrackerIdT getTrackerId() { return trackerId; }
 
@@ -64,6 +65,10 @@ public class TrackerDataT {
 
   public void setRotationIdentityAdjusted(solarxr_protocol.datatypes.math.QuatT rotationIdentityAdjusted) { this.rotationIdentityAdjusted = rotationIdentityAdjusted; }
 
+  public Integer getTps() { return tps; }
+
+  public void setTps(Integer tps) { this.tps = tps; }
+
 
   public TrackerDataT() {
     this.trackerId = null;
@@ -77,6 +82,7 @@ public class TrackerDataT {
     this.linearAcceleration = new solarxr_protocol.datatypes.math.Vec3fT();
     this.rotationReferenceAdjusted = new solarxr_protocol.datatypes.math.QuatT();
     this.rotationIdentityAdjusted = new solarxr_protocol.datatypes.math.QuatT();
+    this.tps = null;
   }
 }
 

--- a/protocol/java/src/solarxr_protocol/datatypes/hardware_info/HardwareStatus.java
+++ b/protocol/java/src/solarxr_protocol/datatypes/hardware_info/HardwareStatus.java
@@ -20,8 +20,6 @@ public final class HardwareStatus extends Table {
 
   public boolean hasErrorStatus() { return 0 != __offset(4); }
   public int errorStatus() { int o = __offset(4); return o != 0 ? bb.get(o + bb_pos) & 0xFF : 0; }
-  public boolean hasTps() { return 0 != __offset(6); }
-  public int tps() { int o = __offset(6); return o != 0 ? bb.get(o + bb_pos) & 0xFF : 0; }
   public boolean hasPing() { return 0 != __offset(8); }
   public int ping() { int o = __offset(8); return o != 0 ? bb.getShort(o + bb_pos) & 0xFFFF : 0; }
   /**
@@ -43,7 +41,6 @@ public final class HardwareStatus extends Table {
 
   public static int createHardwareStatus(FlatBufferBuilder builder,
       int errorStatus,
-      int tps,
       int ping,
       short rssi,
       float mcuTemp,
@@ -57,14 +54,12 @@ public final class HardwareStatus extends Table {
     HardwareStatus.addRssi(builder, rssi);
     HardwareStatus.addPing(builder, ping);
     HardwareStatus.addBatteryPctEstimate(builder, batteryPctEstimate);
-    HardwareStatus.addTps(builder, tps);
     HardwareStatus.addErrorStatus(builder, errorStatus);
     return HardwareStatus.endHardwareStatus(builder);
   }
 
   public static void startHardwareStatus(FlatBufferBuilder builder) { builder.startTable(8); }
   public static void addErrorStatus(FlatBufferBuilder builder, int errorStatus) { builder.addByte(0, (byte) errorStatus, (byte) 0); }
-  public static void addTps(FlatBufferBuilder builder, int tps) { builder.addByte(1, (byte) tps, (byte) 0); }
   public static void addPing(FlatBufferBuilder builder, int ping) { builder.addShort(2, (short) ping, (short) 0); }
   public static void addRssi(FlatBufferBuilder builder, short rssi) { builder.addShort(3, rssi, 0); }
   public static void addMcuTemp(FlatBufferBuilder builder, float mcuTemp) { builder.addFloat(4, mcuTemp, 0f); }
@@ -90,8 +85,6 @@ public final class HardwareStatus extends Table {
   public void unpackTo(HardwareStatusT _o) {
     Integer _oErrorStatus = hasErrorStatus() ? errorStatus() : null;
     _o.setErrorStatus(_oErrorStatus);
-    Integer _oTps = hasTps() ? tps() : null;
-    _o.setTps(_oTps);
     Integer _oPing = hasPing() ? ping() : null;
     _o.setPing(_oPing);
     Short _oRssi = hasRssi() ? rssi() : null;
@@ -111,7 +104,6 @@ public final class HardwareStatus extends Table {
     return createHardwareStatus(
       builder,
       _o.getErrorStatus(),
-      _o.getTps(),
       _o.getPing(),
       _o.getRssi(),
       _o.getMcuTemp(),

--- a/protocol/java/src/solarxr_protocol/datatypes/hardware_info/HardwareStatusT.java
+++ b/protocol/java/src/solarxr_protocol/datatypes/hardware_info/HardwareStatusT.java
@@ -9,7 +9,6 @@ import com.google.flatbuffers.*;
 
 public class HardwareStatusT {
   private Integer errorStatus;
-  private Integer tps;
   private Integer ping;
   private Short rssi;
   private Float mcuTemp;
@@ -20,10 +19,6 @@ public class HardwareStatusT {
   public Integer getErrorStatus() { return errorStatus; }
 
   public void setErrorStatus(Integer errorStatus) { this.errorStatus = errorStatus; }
-
-  public Integer getTps() { return tps; }
-
-  public void setTps(Integer tps) { this.tps = tps; }
 
   public Integer getPing() { return ping; }
 
@@ -52,7 +47,6 @@ public class HardwareStatusT {
 
   public HardwareStatusT() {
     this.errorStatus = null;
-    this.tps = null;
     this.ping = null;
     this.rssi = null;
     this.mcuTemp = null;

--- a/protocol/kotlin/src/solarxr_protocol/data_feed/tracker/TrackerData.kt
+++ b/protocol/kotlin/src/solarxr_protocol/data_feed/tracker/TrackerData.kt
@@ -152,6 +152,14 @@ class TrackerData : Table() {
             null
         }
     }
+    /**
+     * Data ticks per second, processed by SlimeVR server
+     */
+    val tps : UShort?
+        get() {
+            val o = __offset(26)
+            return if(o != 0) bb.getShort(o + bb_pos).toUShort() else null
+        }
     companion object {
         @JvmStatic
         fun validateVersion() = Constants.FLATBUFFERS_22_10_26()
@@ -163,7 +171,7 @@ class TrackerData : Table() {
             return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb))
         }
         @JvmStatic
-        fun startTrackerData(builder: FlatBufferBuilder) = builder.startTable(11)
+        fun startTrackerData(builder: FlatBufferBuilder) = builder.startTable(12)
         @JvmStatic
         fun addTrackerId(builder: FlatBufferBuilder, trackerId: Int) = builder.addOffset(0, trackerId, 0)
         @JvmStatic
@@ -186,6 +194,8 @@ class TrackerData : Table() {
         fun addRotationReferenceAdjusted(builder: FlatBufferBuilder, rotationReferenceAdjusted: Int) = builder.addStruct(9, rotationReferenceAdjusted, 0)
         @JvmStatic
         fun addRotationIdentityAdjusted(builder: FlatBufferBuilder, rotationIdentityAdjusted: Int) = builder.addStruct(10, rotationIdentityAdjusted, 0)
+        @JvmStatic
+        fun addTps(builder: FlatBufferBuilder, tps: UShort) = builder.addShort(11, tps.toShort(), 0)
         @JvmStatic
         fun endTrackerData(builder: FlatBufferBuilder) : Int {
             val o = builder.endTable()

--- a/protocol/kotlin/src/solarxr_protocol/data_feed/tracker/TrackerDataMask.kt
+++ b/protocol/kotlin/src/solarxr_protocol/data_feed/tracker/TrackerDataMask.kt
@@ -69,6 +69,11 @@ class TrackerDataMask : Table() {
             val o = __offset(22)
             return if(o != 0) 0.toByte() != bb.get(o + bb_pos) else false
         }
+    val tps : Boolean
+        get() {
+            val o = __offset(24)
+            return if(o != 0) 0.toByte() != bb.get(o + bb_pos) else false
+        }
     companion object {
         @JvmStatic
         fun validateVersion() = Constants.FLATBUFFERS_22_10_26()
@@ -80,8 +85,9 @@ class TrackerDataMask : Table() {
             return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb))
         }
         @JvmStatic
-        fun createTrackerDataMask(builder: FlatBufferBuilder, info: Boolean, status: Boolean, rotation: Boolean, position: Boolean, rawAngularVelocity: Boolean, rawAcceleration: Boolean, temp: Boolean, linearAcceleration: Boolean, rotationReferenceAdjusted: Boolean, rotationIdentityAdjusted: Boolean) : Int {
-            builder.startTable(10)
+        fun createTrackerDataMask(builder: FlatBufferBuilder, info: Boolean, status: Boolean, rotation: Boolean, position: Boolean, rawAngularVelocity: Boolean, rawAcceleration: Boolean, temp: Boolean, linearAcceleration: Boolean, rotationReferenceAdjusted: Boolean, rotationIdentityAdjusted: Boolean, tps: Boolean) : Int {
+            builder.startTable(11)
+            addTps(builder, tps)
             addRotationIdentityAdjusted(builder, rotationIdentityAdjusted)
             addRotationReferenceAdjusted(builder, rotationReferenceAdjusted)
             addLinearAcceleration(builder, linearAcceleration)
@@ -95,7 +101,7 @@ class TrackerDataMask : Table() {
             return endTrackerDataMask(builder)
         }
         @JvmStatic
-        fun startTrackerDataMask(builder: FlatBufferBuilder) = builder.startTable(10)
+        fun startTrackerDataMask(builder: FlatBufferBuilder) = builder.startTable(11)
         @JvmStatic
         fun addInfo(builder: FlatBufferBuilder, info: Boolean) = builder.addBoolean(0, info, false)
         @JvmStatic
@@ -116,6 +122,8 @@ class TrackerDataMask : Table() {
         fun addRotationReferenceAdjusted(builder: FlatBufferBuilder, rotationReferenceAdjusted: Boolean) = builder.addBoolean(8, rotationReferenceAdjusted, false)
         @JvmStatic
         fun addRotationIdentityAdjusted(builder: FlatBufferBuilder, rotationIdentityAdjusted: Boolean) = builder.addBoolean(9, rotationIdentityAdjusted, false)
+        @JvmStatic
+        fun addTps(builder: FlatBufferBuilder, tps: Boolean) = builder.addBoolean(10, tps, false)
         @JvmStatic
         fun endTrackerDataMask(builder: FlatBufferBuilder) : Int {
             val o = builder.endTable()

--- a/protocol/kotlin/src/solarxr_protocol/datatypes/hardware_info/HardwareStatus.kt
+++ b/protocol/kotlin/src/solarxr_protocol/datatypes/hardware_info/HardwareStatus.kt
@@ -24,11 +24,6 @@ class HardwareStatus : Table() {
             val o = __offset(4)
             return if(o != 0) bb.get(o + bb_pos).toUByte() else null
         }
-    val tps : UByte?
-        get() {
-            val o = __offset(6)
-            return if(o != 0) bb.get(o + bb_pos).toUByte() else null
-        }
     val ping : UShort?
         get() {
             val o = __offset(8)
@@ -80,7 +75,7 @@ class HardwareStatus : Table() {
             return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb))
         }
         @JvmStatic
-        fun createHardwareStatus(builder: FlatBufferBuilder, errorStatus: UByte?, tps: UByte?, ping: UShort?, rssi: Short?, mcuTemp: Float?, batteryVoltage: Float?, batteryPctEstimate: UByte?, logDataOffset: Int) : Int {
+        fun createHardwareStatus(builder: FlatBufferBuilder, errorStatus: UByte?, ping: UShort?, rssi: Short?, mcuTemp: Float?, batteryVoltage: Float?, batteryPctEstimate: UByte?, logDataOffset: Int) : Int {
             builder.startTable(8)
             addLogData(builder, logDataOffset)
             batteryVoltage?.run { addBatteryVoltage(builder, batteryVoltage) }
@@ -88,7 +83,6 @@ class HardwareStatus : Table() {
             rssi?.run { addRssi(builder, rssi) }
             ping?.run { addPing(builder, ping) }
             batteryPctEstimate?.run { addBatteryPctEstimate(builder, batteryPctEstimate) }
-            tps?.run { addTps(builder, tps) }
             errorStatus?.run { addErrorStatus(builder, errorStatus) }
             return endHardwareStatus(builder)
         }
@@ -96,8 +90,6 @@ class HardwareStatus : Table() {
         fun startHardwareStatus(builder: FlatBufferBuilder) = builder.startTable(8)
         @JvmStatic
         fun addErrorStatus(builder: FlatBufferBuilder, errorStatus: UByte) = builder.addByte(0, errorStatus.toByte(), 0)
-        @JvmStatic
-        fun addTps(builder: FlatBufferBuilder, tps: UByte) = builder.addByte(1, tps.toByte(), 0)
         @JvmStatic
         fun addPing(builder: FlatBufferBuilder, ping: UShort) = builder.addShort(2, ping.toShort(), 0)
         @JvmStatic

--- a/protocol/rust/src/generated/solarxr_protocol/data_feed/tracker/tracker_data_generated.rs
+++ b/protocol/rust/src/generated/solarxr_protocol/data_feed/tracker/tracker_data_generated.rs
@@ -41,6 +41,7 @@ impl<'a> TrackerData<'a> {
   pub const VT_LINEAR_ACCELERATION: flatbuffers::VOffsetT = 20;
   pub const VT_ROTATION_REFERENCE_ADJUSTED: flatbuffers::VOffsetT = 22;
   pub const VT_ROTATION_IDENTITY_ADJUSTED: flatbuffers::VOffsetT = 24;
+  pub const VT_TPS: flatbuffers::VOffsetT = 26;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -62,6 +63,7 @@ impl<'a> TrackerData<'a> {
     if let Some(x) = args.rotation { builder.add_rotation(x); }
     if let Some(x) = args.info { builder.add_info(x); }
     if let Some(x) = args.tracker_id { builder.add_tracker_id(x); }
+    if let Some(x) = args.tps { builder.add_tps(x); }
     builder.add_status(args.status);
     builder.finish()
   }
@@ -162,6 +164,14 @@ impl<'a> TrackerData<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<super::super::datatypes::math::Quat>(TrackerData::VT_ROTATION_IDENTITY_ADJUSTED, None)}
   }
+  /// Data ticks per second, processed by SlimeVR server
+  #[inline]
+  pub fn tps(&self) -> Option<u16> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u16>(TrackerData::VT_TPS, None)}
+  }
 }
 
 impl flatbuffers::Verifiable for TrackerData<'_> {
@@ -182,6 +192,7 @@ impl flatbuffers::Verifiable for TrackerData<'_> {
      .visit_field::<super::super::datatypes::math::Vec3f>("linear_acceleration", Self::VT_LINEAR_ACCELERATION, false)?
      .visit_field::<super::super::datatypes::math::Quat>("rotation_reference_adjusted", Self::VT_ROTATION_REFERENCE_ADJUSTED, false)?
      .visit_field::<super::super::datatypes::math::Quat>("rotation_identity_adjusted", Self::VT_ROTATION_IDENTITY_ADJUSTED, false)?
+     .visit_field::<u16>("tps", Self::VT_TPS, false)?
      .finish();
     Ok(())
   }
@@ -198,6 +209,7 @@ pub struct TrackerDataArgs<'a> {
     pub linear_acceleration: Option<&'a super::super::datatypes::math::Vec3f>,
     pub rotation_reference_adjusted: Option<&'a super::super::datatypes::math::Quat>,
     pub rotation_identity_adjusted: Option<&'a super::super::datatypes::math::Quat>,
+    pub tps: Option<u16>,
 }
 impl<'a> Default for TrackerDataArgs<'a> {
   #[inline]
@@ -214,6 +226,7 @@ impl<'a> Default for TrackerDataArgs<'a> {
       linear_acceleration: None,
       rotation_reference_adjusted: None,
       rotation_identity_adjusted: None,
+      tps: None,
     }
   }
 }
@@ -268,6 +281,10 @@ impl<'a: 'b, 'b> TrackerDataBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<&super::super::datatypes::math::Quat>(TrackerData::VT_ROTATION_IDENTITY_ADJUSTED, rotation_identity_adjusted);
   }
   #[inline]
+  pub fn add_tps(&mut self, tps: u16) {
+    self.fbb_.push_slot_always::<u16>(TrackerData::VT_TPS, tps);
+  }
+  #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TrackerDataBuilder<'a, 'b> {
     let start = _fbb.start_table();
     TrackerDataBuilder {
@@ -296,6 +313,7 @@ impl core::fmt::Debug for TrackerData<'_> {
       ds.field("linear_acceleration", &self.linear_acceleration());
       ds.field("rotation_reference_adjusted", &self.rotation_reference_adjusted());
       ds.field("rotation_identity_adjusted", &self.rotation_identity_adjusted());
+      ds.field("tps", &self.tps());
       ds.finish()
   }
 }

--- a/protocol/rust/src/generated/solarxr_protocol/data_feed/tracker/tracker_data_mask_generated.rs
+++ b/protocol/rust/src/generated/solarxr_protocol/data_feed/tracker/tracker_data_mask_generated.rs
@@ -36,6 +36,7 @@ impl<'a> TrackerDataMask<'a> {
   pub const VT_LINEAR_ACCELERATION: flatbuffers::VOffsetT = 18;
   pub const VT_ROTATION_REFERENCE_ADJUSTED: flatbuffers::VOffsetT = 20;
   pub const VT_ROTATION_IDENTITY_ADJUSTED: flatbuffers::VOffsetT = 22;
+  pub const VT_TPS: flatbuffers::VOffsetT = 24;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -47,6 +48,7 @@ impl<'a> TrackerDataMask<'a> {
     args: &'args TrackerDataMaskArgs
   ) -> flatbuffers::WIPOffset<TrackerDataMask<'bldr>> {
     let mut builder = TrackerDataMaskBuilder::new(_fbb);
+    builder.add_tps(args.tps);
     builder.add_rotation_identity_adjusted(args.rotation_identity_adjusted);
     builder.add_rotation_reference_adjusted(args.rotation_reference_adjusted);
     builder.add_linear_acceleration(args.linear_acceleration);
@@ -131,6 +133,13 @@ impl<'a> TrackerDataMask<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<bool>(TrackerDataMask::VT_ROTATION_IDENTITY_ADJUSTED, Some(false)).unwrap()}
   }
+  #[inline]
+  pub fn tps(&self) -> bool {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<bool>(TrackerDataMask::VT_TPS, Some(false)).unwrap()}
+  }
 }
 
 impl flatbuffers::Verifiable for TrackerDataMask<'_> {
@@ -150,6 +159,7 @@ impl flatbuffers::Verifiable for TrackerDataMask<'_> {
      .visit_field::<bool>("linear_acceleration", Self::VT_LINEAR_ACCELERATION, false)?
      .visit_field::<bool>("rotation_reference_adjusted", Self::VT_ROTATION_REFERENCE_ADJUSTED, false)?
      .visit_field::<bool>("rotation_identity_adjusted", Self::VT_ROTATION_IDENTITY_ADJUSTED, false)?
+     .visit_field::<bool>("tps", Self::VT_TPS, false)?
      .finish();
     Ok(())
   }
@@ -165,6 +175,7 @@ pub struct TrackerDataMaskArgs {
     pub linear_acceleration: bool,
     pub rotation_reference_adjusted: bool,
     pub rotation_identity_adjusted: bool,
+    pub tps: bool,
 }
 impl<'a> Default for TrackerDataMaskArgs {
   #[inline]
@@ -180,6 +191,7 @@ impl<'a> Default for TrackerDataMaskArgs {
       linear_acceleration: false,
       rotation_reference_adjusted: false,
       rotation_identity_adjusted: false,
+      tps: false,
     }
   }
 }
@@ -230,6 +242,10 @@ impl<'a: 'b, 'b> TrackerDataMaskBuilder<'a, 'b> {
     self.fbb_.push_slot::<bool>(TrackerDataMask::VT_ROTATION_IDENTITY_ADJUSTED, rotation_identity_adjusted, false);
   }
   #[inline]
+  pub fn add_tps(&mut self, tps: bool) {
+    self.fbb_.push_slot::<bool>(TrackerDataMask::VT_TPS, tps, false);
+  }
+  #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TrackerDataMaskBuilder<'a, 'b> {
     let start = _fbb.start_table();
     TrackerDataMaskBuilder {
@@ -257,6 +273,7 @@ impl core::fmt::Debug for TrackerDataMask<'_> {
       ds.field("linear_acceleration", &self.linear_acceleration());
       ds.field("rotation_reference_adjusted", &self.rotation_reference_adjusted());
       ds.field("rotation_identity_adjusted", &self.rotation_identity_adjusted());
+      ds.field("tps", &self.tps());
       ds.finish()
   }
 }

--- a/protocol/rust/src/generated/solarxr_protocol/datatypes/hardware_info/hardware_status_generated.rs
+++ b/protocol/rust/src/generated/solarxr_protocol/datatypes/hardware_info/hardware_status_generated.rs
@@ -27,7 +27,6 @@ impl<'a> flatbuffers::Follow<'a> for HardwareStatus<'a> {
 
 impl<'a> HardwareStatus<'a> {
   pub const VT_ERROR_STATUS: flatbuffers::VOffsetT = 4;
-  pub const VT_TPS: flatbuffers::VOffsetT = 6;
   pub const VT_PING: flatbuffers::VOffsetT = 8;
   pub const VT_RSSI: flatbuffers::VOffsetT = 10;
   pub const VT_MCU_TEMP: flatbuffers::VOffsetT = 12;
@@ -51,7 +50,6 @@ impl<'a> HardwareStatus<'a> {
     if let Some(x) = args.rssi { builder.add_rssi(x); }
     if let Some(x) = args.ping { builder.add_ping(x); }
     if let Some(x) = args.battery_pct_estimate { builder.add_battery_pct_estimate(x); }
-    if let Some(x) = args.tps { builder.add_tps(x); }
     if let Some(x) = args.error_status { builder.add_error_status(x); }
     builder.finish()
   }
@@ -63,13 +61,6 @@ impl<'a> HardwareStatus<'a> {
     // Created from valid Table for this object
     // which contains a valid value in this slot
     unsafe { self._tab.get::<super::FirmwareErrorCode>(HardwareStatus::VT_ERROR_STATUS, None)}
-  }
-  #[inline]
-  pub fn tps(&self) -> Option<u8> {
-    // Safety:
-    // Created from valid Table for this object
-    // which contains a valid value in this slot
-    unsafe { self._tab.get::<u8>(HardwareStatus::VT_TPS, None)}
   }
   #[inline]
   pub fn ping(&self) -> Option<u16> {
@@ -125,7 +116,6 @@ impl flatbuffers::Verifiable for HardwareStatus<'_> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
      .visit_field::<super::FirmwareErrorCode>("error_status", Self::VT_ERROR_STATUS, false)?
-     .visit_field::<u8>("tps", Self::VT_TPS, false)?
      .visit_field::<u16>("ping", Self::VT_PING, false)?
      .visit_field::<i16>("rssi", Self::VT_RSSI, false)?
      .visit_field::<f32>("mcu_temp", Self::VT_MCU_TEMP, false)?
@@ -138,7 +128,6 @@ impl flatbuffers::Verifiable for HardwareStatus<'_> {
 }
 pub struct HardwareStatusArgs<'a> {
     pub error_status: Option<super::FirmwareErrorCode>,
-    pub tps: Option<u8>,
     pub ping: Option<u16>,
     pub rssi: Option<i16>,
     pub mcu_temp: Option<f32>,
@@ -151,7 +140,6 @@ impl<'a> Default for HardwareStatusArgs<'a> {
   fn default() -> Self {
     HardwareStatusArgs {
       error_status: None,
-      tps: None,
       ping: None,
       rssi: None,
       mcu_temp: None,
@@ -170,10 +158,6 @@ impl<'a: 'b, 'b> HardwareStatusBuilder<'a, 'b> {
   #[inline]
   pub fn add_error_status(&mut self, error_status: super::FirmwareErrorCode) {
     self.fbb_.push_slot_always::<super::FirmwareErrorCode>(HardwareStatus::VT_ERROR_STATUS, error_status);
-  }
-  #[inline]
-  pub fn add_tps(&mut self, tps: u8) {
-    self.fbb_.push_slot_always::<u8>(HardwareStatus::VT_TPS, tps);
   }
   #[inline]
   pub fn add_ping(&mut self, ping: u16) {
@@ -218,7 +202,6 @@ impl core::fmt::Debug for HardwareStatus<'_> {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
     let mut ds = f.debug_struct("HardwareStatus");
       ds.field("error_status", &self.error_status());
-      ds.field("tps", &self.tps());
       ds.field("ping", &self.ping());
       ds.field("rssi", &self.rssi());
       ds.field("mcu_temp", &self.mcu_temp());

--- a/protocol/typescript/src/solarxr-protocol/data-feed/tracker/tracker-data-mask.ts
+++ b/protocol/typescript/src/solarxr-protocol/data-feed/tracker/tracker-data-mask.ts
@@ -75,8 +75,13 @@ rotationIdentityAdjusted():boolean {
   return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
 }
 
+tps():boolean {
+  const offset = this.bb!.__offset(this.bb_pos, 24);
+  return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
+}
+
 static startTrackerDataMask(builder:flatbuffers.Builder) {
-  builder.startObject(10);
+  builder.startObject(11);
 }
 
 static addInfo(builder:flatbuffers.Builder, info:boolean) {
@@ -119,12 +124,16 @@ static addRotationIdentityAdjusted(builder:flatbuffers.Builder, rotationIdentity
   builder.addFieldInt8(9, +rotationIdentityAdjusted, +false);
 }
 
+static addTps(builder:flatbuffers.Builder, tps:boolean) {
+  builder.addFieldInt8(10, +tps, +false);
+}
+
 static endTrackerDataMask(builder:flatbuffers.Builder):flatbuffers.Offset {
   const offset = builder.endObject();
   return offset;
 }
 
-static createTrackerDataMask(builder:flatbuffers.Builder, info:boolean, status:boolean, rotation:boolean, position:boolean, rawAngularVelocity:boolean, rawAcceleration:boolean, temp:boolean, linearAcceleration:boolean, rotationReferenceAdjusted:boolean, rotationIdentityAdjusted:boolean):flatbuffers.Offset {
+static createTrackerDataMask(builder:flatbuffers.Builder, info:boolean, status:boolean, rotation:boolean, position:boolean, rawAngularVelocity:boolean, rawAcceleration:boolean, temp:boolean, linearAcceleration:boolean, rotationReferenceAdjusted:boolean, rotationIdentityAdjusted:boolean, tps:boolean):flatbuffers.Offset {
   TrackerDataMask.startTrackerDataMask(builder);
   TrackerDataMask.addInfo(builder, info);
   TrackerDataMask.addStatus(builder, status);
@@ -136,6 +145,7 @@ static createTrackerDataMask(builder:flatbuffers.Builder, info:boolean, status:b
   TrackerDataMask.addLinearAcceleration(builder, linearAcceleration);
   TrackerDataMask.addRotationReferenceAdjusted(builder, rotationReferenceAdjusted);
   TrackerDataMask.addRotationIdentityAdjusted(builder, rotationIdentityAdjusted);
+  TrackerDataMask.addTps(builder, tps);
   return TrackerDataMask.endTrackerDataMask(builder);
 }
 
@@ -150,7 +160,8 @@ unpack(): TrackerDataMaskT {
     this.temp(),
     this.linearAcceleration(),
     this.rotationReferenceAdjusted(),
-    this.rotationIdentityAdjusted()
+    this.rotationIdentityAdjusted(),
+    this.tps()
   );
 }
 
@@ -166,6 +177,7 @@ unpackTo(_o: TrackerDataMaskT): void {
   _o.linearAcceleration = this.linearAcceleration();
   _o.rotationReferenceAdjusted = this.rotationReferenceAdjusted();
   _o.rotationIdentityAdjusted = this.rotationIdentityAdjusted();
+  _o.tps = this.tps();
 }
 }
 
@@ -180,7 +192,8 @@ constructor(
   public temp: boolean = false,
   public linearAcceleration: boolean = false,
   public rotationReferenceAdjusted: boolean = false,
-  public rotationIdentityAdjusted: boolean = false
+  public rotationIdentityAdjusted: boolean = false,
+  public tps: boolean = false
 ){}
 
 
@@ -195,7 +208,8 @@ pack(builder:flatbuffers.Builder): flatbuffers.Offset {
     this.temp,
     this.linearAcceleration,
     this.rotationReferenceAdjusted,
-    this.rotationIdentityAdjusted
+    this.rotationIdentityAdjusted,
+    this.tps
   );
 }
 }

--- a/protocol/typescript/src/solarxr-protocol/data-feed/tracker/tracker-data.ts
+++ b/protocol/typescript/src/solarxr-protocol/data-feed/tracker/tracker-data.ts
@@ -124,8 +124,16 @@ rotationIdentityAdjusted(obj?:Quat):Quat|null {
   return offset ? (obj || new Quat()).__init(this.bb_pos + offset, this.bb!) : null;
 }
 
+/**
+ * Data ticks per second, processed by SlimeVR server
+ */
+tps():number|null {
+  const offset = this.bb!.__offset(this.bb_pos, 26);
+  return offset ? this.bb!.readUint16(this.bb_pos + offset) : null;
+}
+
 static startTrackerData(builder:flatbuffers.Builder) {
-  builder.startObject(11);
+  builder.startObject(12);
 }
 
 static addTrackerId(builder:flatbuffers.Builder, trackerIdOffset:flatbuffers.Offset) {
@@ -172,6 +180,10 @@ static addRotationIdentityAdjusted(builder:flatbuffers.Builder, rotationIdentity
   builder.addFieldStruct(10, rotationIdentityAdjustedOffset, 0);
 }
 
+static addTps(builder:flatbuffers.Builder, tps:number) {
+  builder.addFieldInt16(11, tps, 0);
+}
+
 static endTrackerData(builder:flatbuffers.Builder):flatbuffers.Offset {
   const offset = builder.endObject();
   return offset;
@@ -190,7 +202,8 @@ unpack(): TrackerDataT {
     (this.temp() !== null ? this.temp()!.unpack() : null),
     (this.linearAcceleration() !== null ? this.linearAcceleration()!.unpack() : null),
     (this.rotationReferenceAdjusted() !== null ? this.rotationReferenceAdjusted()!.unpack() : null),
-    (this.rotationIdentityAdjusted() !== null ? this.rotationIdentityAdjusted()!.unpack() : null)
+    (this.rotationIdentityAdjusted() !== null ? this.rotationIdentityAdjusted()!.unpack() : null),
+    this.tps()
   );
 }
 
@@ -207,6 +220,7 @@ unpackTo(_o: TrackerDataT): void {
   _o.linearAcceleration = (this.linearAcceleration() !== null ? this.linearAcceleration()!.unpack() : null);
   _o.rotationReferenceAdjusted = (this.rotationReferenceAdjusted() !== null ? this.rotationReferenceAdjusted()!.unpack() : null);
   _o.rotationIdentityAdjusted = (this.rotationIdentityAdjusted() !== null ? this.rotationIdentityAdjusted()!.unpack() : null);
+  _o.tps = this.tps();
 }
 }
 
@@ -222,7 +236,8 @@ constructor(
   public temp: TemperatureT|null = null,
   public linearAcceleration: Vec3fT|null = null,
   public rotationReferenceAdjusted: QuatT|null = null,
-  public rotationIdentityAdjusted: QuatT|null = null
+  public rotationIdentityAdjusted: QuatT|null = null,
+  public tps: number|null = null
 ){}
 
 
@@ -242,6 +257,8 @@ pack(builder:flatbuffers.Builder): flatbuffers.Offset {
   TrackerData.addLinearAcceleration(builder, (this.linearAcceleration !== null ? this.linearAcceleration!.pack(builder) : 0));
   TrackerData.addRotationReferenceAdjusted(builder, (this.rotationReferenceAdjusted !== null ? this.rotationReferenceAdjusted!.pack(builder) : 0));
   TrackerData.addRotationIdentityAdjusted(builder, (this.rotationIdentityAdjusted !== null ? this.rotationIdentityAdjusted!.pack(builder) : 0));
+  if (this.tps !== null)
+    TrackerData.addTps(builder, this.tps);
 
   return TrackerData.endTrackerData(builder);
 }

--- a/protocol/typescript/src/solarxr-protocol/datatypes/hardware-info/hardware-status.ts
+++ b/protocol/typescript/src/solarxr-protocol/datatypes/hardware-info/hardware-status.ts
@@ -32,11 +32,6 @@ errorStatus():FirmwareErrorCode|null {
   return offset ? this.bb!.readUint8(this.bb_pos + offset) : null;
 }
 
-tps():number|null {
-  const offset = this.bb!.__offset(this.bb_pos, 6);
-  return offset ? this.bb!.readUint8(this.bb_pos + offset) : null;
-}
-
 ping():number|null {
   const offset = this.bb!.__offset(this.bb_pos, 8);
   return offset ? this.bb!.readUint16(this.bb_pos + offset) : null;
@@ -81,10 +76,6 @@ static addErrorStatus(builder:flatbuffers.Builder, errorStatus:FirmwareErrorCode
   builder.addFieldInt8(0, errorStatus, 0);
 }
 
-static addTps(builder:flatbuffers.Builder, tps:number) {
-  builder.addFieldInt8(1, tps, 0);
-}
-
 static addPing(builder:flatbuffers.Builder, ping:number) {
   builder.addFieldInt16(2, ping, 0);
 }
@@ -118,7 +109,6 @@ static endHardwareStatus(builder:flatbuffers.Builder):flatbuffers.Offset {
 unpack(): HardwareStatusT {
   return new HardwareStatusT(
     this.errorStatus(),
-    this.tps(),
     this.ping(),
     this.rssi(),
     this.mcuTemp(),
@@ -131,7 +121,6 @@ unpack(): HardwareStatusT {
 
 unpackTo(_o: HardwareStatusT): void {
   _o.errorStatus = this.errorStatus();
-  _o.tps = this.tps();
   _o.ping = this.ping();
   _o.rssi = this.rssi();
   _o.mcuTemp = this.mcuTemp();
@@ -144,7 +133,6 @@ unpackTo(_o: HardwareStatusT): void {
 export class HardwareStatusT implements flatbuffers.IGeneratedObject {
 constructor(
   public errorStatus: FirmwareErrorCode|null = null,
-  public tps: number|null = null,
   public ping: number|null = null,
   public rssi: number|null = null,
   public mcuTemp: number|null = null,
@@ -160,8 +148,6 @@ pack(builder:flatbuffers.Builder): flatbuffers.Offset {
   HardwareStatus.startHardwareStatus(builder);
   if (this.errorStatus !== null)
     HardwareStatus.addErrorStatus(builder, this.errorStatus);
-  if (this.tps !== null)
-    HardwareStatus.addTps(builder, this.tps);
   if (this.ping !== null)
     HardwareStatus.addPing(builder, this.ping);
   if (this.rssi !== null)

--- a/schema/data_feed/tracker.fbs
+++ b/schema/data_feed/tracker.fbs
@@ -45,6 +45,9 @@ table TrackerData {
     /// Includes: only full and quick reset adjustments.
     /// This rotation can be used in visualizations for IMU debugging.
     rotation_identity_adjusted: solarxr_protocol.datatypes.math.Quat;
+
+    /// Data ticks per second, processed by SlimeVR server
+    tps: uint16 = null;
 }
 
 /// A mask of the different components in `TrackerComponent`
@@ -59,6 +62,7 @@ table TrackerDataMask {
     linear_acceleration: bool;
     rotation_reference_adjusted: bool;
     rotation_identity_adjusted: bool;
+    tps: bool;
 }
 
 /// Static description of a tracker

--- a/schema/datatypes/hardware_info.fbs
+++ b/schema/datatypes/hardware_info.fbs
@@ -55,7 +55,7 @@ table HardwareInfo {
 /// Mostly-dynamic status info about a tracked device's firmware
 table HardwareStatus {
     error_status: solarxr_protocol.datatypes.FirmwareErrorCode = null;
-    tps: uint8 = null;
+    tps: uint8 = null (deprecated);
     ping: uint16 = null;
     /// “Received Signal Strength Indicator" between device and wifi adapter in dBm
     rssi: int16 = null;


### PR DESCRIPTION
If an aux tracker is connected GUI shows its TPS identical to the main tracker, which is incorrect. We need to have a TPS field for each tracker instead of just 1 field for the whole device.

This PR also expands TPS type from `uint8` to `uint16`, because SteamVR can send updates faster than 255/s and it wraps around.

Server PR will be submitted after merging https://github.com/SlimeVR/SlimeVR-Server/pull/647.
