### PR TITLE
Add mirror_tracking to VMCOSCSettings

### DIFF
--- a/protocol/cpp/include/solarxr_protocol/generated/all_generated.h
+++ b/protocol/cpp/include/solarxr_protocol/generated/all_generated.h
@@ -5551,7 +5551,8 @@ struct VMCOSCSettings FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OSC_SETTINGS = 4,
     VT_VRM_JSON = 6,
-    VT_ANCHOR_HIP = 8
+    VT_ANCHOR_HIP = 8,
+    VT_MIRROR_TRACKING = 10
   };
   const solarxr_protocol::rpc::OSCSettings *osc_settings() const {
     return GetPointer<const solarxr_protocol::rpc::OSCSettings *>(VT_OSC_SETTINGS);
@@ -5562,6 +5563,9 @@ struct VMCOSCSettings FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool anchor_hip() const {
     return GetField<uint8_t>(VT_ANCHOR_HIP, 0) != 0;
   }
+  bool mirror_tracking() const {
+    return GetField<uint8_t>(VT_MIRROR_TRACKING, 0) != 0;
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_OSC_SETTINGS) &&
@@ -5569,6 +5573,7 @@ struct VMCOSCSettings FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyOffset(verifier, VT_VRM_JSON) &&
            verifier.VerifyString(vrm_json()) &&
            VerifyField<uint8_t>(verifier, VT_ANCHOR_HIP, 1) &&
+           VerifyField<uint8_t>(verifier, VT_MIRROR_TRACKING, 1) &&
            verifier.EndTable();
   }
 };
@@ -5586,6 +5591,9 @@ struct VMCOSCSettingsBuilder {
   void add_anchor_hip(bool anchor_hip) {
     fbb_.AddElement<uint8_t>(VMCOSCSettings::VT_ANCHOR_HIP, static_cast<uint8_t>(anchor_hip), 0);
   }
+  void add_mirror_tracking(bool mirror_tracking) {
+    fbb_.AddElement<uint8_t>(VMCOSCSettings::VT_MIRROR_TRACKING, static_cast<uint8_t>(mirror_tracking), 0);
+  }
   explicit VMCOSCSettingsBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -5601,10 +5609,12 @@ inline flatbuffers::Offset<VMCOSCSettings> CreateVMCOSCSettings(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<solarxr_protocol::rpc::OSCSettings> osc_settings = 0,
     flatbuffers::Offset<flatbuffers::String> vrm_json = 0,
-    bool anchor_hip = false) {
+    bool anchor_hip = false,
+    bool mirror_tracking = false) {
   VMCOSCSettingsBuilder builder_(_fbb);
   builder_.add_vrm_json(vrm_json);
   builder_.add_osc_settings(osc_settings);
+  builder_.add_mirror_tracking(mirror_tracking);
   builder_.add_anchor_hip(anchor_hip);
   return builder_.Finish();
 }
@@ -5613,13 +5623,15 @@ inline flatbuffers::Offset<VMCOSCSettings> CreateVMCOSCSettingsDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<solarxr_protocol::rpc::OSCSettings> osc_settings = 0,
     const char *vrm_json = nullptr,
-    bool anchor_hip = false) {
+    bool anchor_hip = false,
+    bool mirror_tracking = false) {
   auto vrm_json__ = vrm_json ? _fbb.CreateString(vrm_json) : 0;
   return solarxr_protocol::rpc::CreateVMCOSCSettings(
       _fbb,
       osc_settings,
       vrm_json__,
-      anchor_hip);
+      anchor_hip,
+      mirror_tracking);
 }
 
 /// OSC Settings that are used in *any* osc application.

--- a/protocol/java/src/solarxr_protocol/rpc/VMCOSCSettings.java
+++ b/protocol/java/src/solarxr_protocol/rpc/VMCOSCSettings.java
@@ -24,22 +24,26 @@ public final class VMCOSCSettings extends Table {
   public ByteBuffer vrmJsonAsByteBuffer() { return __vector_as_bytebuffer(6, 1); }
   public ByteBuffer vrmJsonInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 6, 1); }
   public boolean anchorHip() { int o = __offset(8); return o != 0 ? 0!=bb.get(o + bb_pos) : false; }
+  public boolean mirrorTracking() { int o = __offset(10); return o != 0 ? 0!=bb.get(o + bb_pos) : false; }
 
   public static int createVMCOSCSettings(FlatBufferBuilder builder,
       int oscSettingsOffset,
       int vrmJsonOffset,
-      boolean anchorHip) {
-    builder.startTable(3);
+      boolean anchorHip,
+      boolean mirrorTracking) {
+    builder.startTable(4);
     VMCOSCSettings.addVrmJson(builder, vrmJsonOffset);
     VMCOSCSettings.addOscSettings(builder, oscSettingsOffset);
+    VMCOSCSettings.addMirrorTracking(builder, mirrorTracking);
     VMCOSCSettings.addAnchorHip(builder, anchorHip);
     return VMCOSCSettings.endVMCOSCSettings(builder);
   }
 
-  public static void startVMCOSCSettings(FlatBufferBuilder builder) { builder.startTable(3); }
+  public static void startVMCOSCSettings(FlatBufferBuilder builder) { builder.startTable(4); }
   public static void addOscSettings(FlatBufferBuilder builder, int oscSettingsOffset) { builder.addOffset(0, oscSettingsOffset, 0); }
   public static void addVrmJson(FlatBufferBuilder builder, int vrmJsonOffset) { builder.addOffset(1, vrmJsonOffset, 0); }
   public static void addAnchorHip(FlatBufferBuilder builder, boolean anchorHip) { builder.addBoolean(2, anchorHip, false); }
+  public static void addMirrorTracking(FlatBufferBuilder builder, boolean mirrorTracking) { builder.addBoolean(3, mirrorTracking, false); }
   public static int endVMCOSCSettings(FlatBufferBuilder builder) {
     int o = builder.endTable();
     return o;
@@ -63,6 +67,8 @@ public final class VMCOSCSettings extends Table {
     _o.setVrmJson(_oVrmJson);
     boolean _oAnchorHip = anchorHip();
     _o.setAnchorHip(_oAnchorHip);
+    boolean _oMirrorTracking = mirrorTracking();
+    _o.setMirrorTracking(_oMirrorTracking);
   }
   public static int pack(FlatBufferBuilder builder, VMCOSCSettingsT _o) {
     if (_o == null) return 0;
@@ -72,7 +78,8 @@ public final class VMCOSCSettings extends Table {
       builder,
       _oscSettings,
       _vrmJson,
-      _o.getAnchorHip());
+      _o.getAnchorHip(),
+      _o.getMirrorTracking());
   }
 }
 

--- a/protocol/java/src/solarxr_protocol/rpc/VMCOSCSettingsT.java
+++ b/protocol/java/src/solarxr_protocol/rpc/VMCOSCSettingsT.java
@@ -11,6 +11,7 @@ public class VMCOSCSettingsT {
   private solarxr_protocol.rpc.OSCSettingsT oscSettings;
   private String vrmJson;
   private boolean anchorHip;
+  private boolean mirrorTracking;
 
   public solarxr_protocol.rpc.OSCSettingsT getOscSettings() { return oscSettings; }
 
@@ -24,11 +25,16 @@ public class VMCOSCSettingsT {
 
   public void setAnchorHip(boolean anchorHip) { this.anchorHip = anchorHip; }
 
+  public boolean getMirrorTracking() { return mirrorTracking; }
+
+  public void setMirrorTracking(boolean mirrorTracking) { this.mirrorTracking = mirrorTracking; }
+
 
   public VMCOSCSettingsT() {
     this.oscSettings = null;
     this.vrmJson = null;
     this.anchorHip = false;
+    this.mirrorTracking = false;
   }
 }
 

--- a/protocol/kotlin/src/solarxr_protocol/rpc/VMCOSCSettings.kt
+++ b/protocol/kotlin/src/solarxr_protocol/rpc/VMCOSCSettings.kt
@@ -40,6 +40,11 @@ class VMCOSCSettings : Table() {
             val o = __offset(8)
             return if(o != 0) 0.toByte() != bb.get(o + bb_pos) else false
         }
+    val mirrorTracking : Boolean
+        get() {
+            val o = __offset(10)
+            return if(o != 0) 0.toByte() != bb.get(o + bb_pos) else false
+        }
     companion object {
         @JvmStatic
         fun validateVersion() = Constants.FLATBUFFERS_22_10_26()
@@ -51,21 +56,24 @@ class VMCOSCSettings : Table() {
             return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb))
         }
         @JvmStatic
-        fun createVMCOSCSettings(builder: FlatBufferBuilder, oscSettingsOffset: Int, vrmJsonOffset: Int, anchorHip: Boolean) : Int {
-            builder.startTable(3)
+        fun createVMCOSCSettings(builder: FlatBufferBuilder, oscSettingsOffset: Int, vrmJsonOffset: Int, anchorHip: Boolean, mirrorTracking: Boolean) : Int {
+            builder.startTable(4)
             addVrmJson(builder, vrmJsonOffset)
             addOscSettings(builder, oscSettingsOffset)
+            addMirrorTracking(builder, mirrorTracking)
             addAnchorHip(builder, anchorHip)
             return endVMCOSCSettings(builder)
         }
         @JvmStatic
-        fun startVMCOSCSettings(builder: FlatBufferBuilder) = builder.startTable(3)
+        fun startVMCOSCSettings(builder: FlatBufferBuilder) = builder.startTable(4)
         @JvmStatic
         fun addOscSettings(builder: FlatBufferBuilder, oscSettings: Int) = builder.addOffset(0, oscSettings, 0)
         @JvmStatic
         fun addVrmJson(builder: FlatBufferBuilder, vrmJson: Int) = builder.addOffset(1, vrmJson, 0)
         @JvmStatic
         fun addAnchorHip(builder: FlatBufferBuilder, anchorHip: Boolean) = builder.addBoolean(2, anchorHip, false)
+        @JvmStatic
+        fun addMirrorTracking(builder: FlatBufferBuilder, mirrorTracking: Boolean) = builder.addBoolean(3, mirrorTracking, false)
         @JvmStatic
         fun endVMCOSCSettings(builder: FlatBufferBuilder) : Int {
             val o = builder.endTable()

--- a/protocol/rust/src/generated/solarxr_protocol/rpc/vmcoscsettings_generated.rs
+++ b/protocol/rust/src/generated/solarxr_protocol/rpc/vmcoscsettings_generated.rs
@@ -29,6 +29,7 @@ impl<'a> VMCOSCSettings<'a> {
   pub const VT_OSC_SETTINGS: flatbuffers::VOffsetT = 4;
   pub const VT_VRM_JSON: flatbuffers::VOffsetT = 6;
   pub const VT_ANCHOR_HIP: flatbuffers::VOffsetT = 8;
+  pub const VT_MIRROR_TRACKING: flatbuffers::VOffsetT = 10;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -42,6 +43,7 @@ impl<'a> VMCOSCSettings<'a> {
     let mut builder = VMCOSCSettingsBuilder::new(_fbb);
     if let Some(x) = args.vrm_json { builder.add_vrm_json(x); }
     if let Some(x) = args.osc_settings { builder.add_osc_settings(x); }
+    builder.add_mirror_tracking(args.mirror_tracking);
     builder.add_anchor_hip(args.anchor_hip);
     builder.finish()
   }
@@ -68,6 +70,13 @@ impl<'a> VMCOSCSettings<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<bool>(VMCOSCSettings::VT_ANCHOR_HIP, Some(false)).unwrap()}
   }
+  #[inline]
+  pub fn mirror_tracking(&self) -> bool {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<bool>(VMCOSCSettings::VT_MIRROR_TRACKING, Some(false)).unwrap()}
+  }
 }
 
 impl flatbuffers::Verifiable for VMCOSCSettings<'_> {
@@ -80,6 +89,7 @@ impl flatbuffers::Verifiable for VMCOSCSettings<'_> {
      .visit_field::<flatbuffers::ForwardsUOffset<OSCSettings>>("osc_settings", Self::VT_OSC_SETTINGS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<&str>>("vrm_json", Self::VT_VRM_JSON, false)?
      .visit_field::<bool>("anchor_hip", Self::VT_ANCHOR_HIP, false)?
+     .visit_field::<bool>("mirror_tracking", Self::VT_MIRROR_TRACKING, false)?
      .finish();
     Ok(())
   }
@@ -88,6 +98,7 @@ pub struct VMCOSCSettingsArgs<'a> {
     pub osc_settings: Option<flatbuffers::WIPOffset<OSCSettings<'a>>>,
     pub vrm_json: Option<flatbuffers::WIPOffset<&'a str>>,
     pub anchor_hip: bool,
+    pub mirror_tracking: bool,
 }
 impl<'a> Default for VMCOSCSettingsArgs<'a> {
   #[inline]
@@ -96,6 +107,7 @@ impl<'a> Default for VMCOSCSettingsArgs<'a> {
       osc_settings: None,
       vrm_json: None,
       anchor_hip: false,
+      mirror_tracking: false,
     }
   }
 }
@@ -118,6 +130,10 @@ impl<'a: 'b, 'b> VMCOSCSettingsBuilder<'a, 'b> {
     self.fbb_.push_slot::<bool>(VMCOSCSettings::VT_ANCHOR_HIP, anchor_hip, false);
   }
   #[inline]
+  pub fn add_mirror_tracking(&mut self, mirror_tracking: bool) {
+    self.fbb_.push_slot::<bool>(VMCOSCSettings::VT_MIRROR_TRACKING, mirror_tracking, false);
+  }
+  #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> VMCOSCSettingsBuilder<'a, 'b> {
     let start = _fbb.start_table();
     VMCOSCSettingsBuilder {
@@ -138,6 +154,7 @@ impl core::fmt::Debug for VMCOSCSettings<'_> {
       ds.field("osc_settings", &self.osc_settings());
       ds.field("vrm_json", &self.vrm_json());
       ds.field("anchor_hip", &self.anchor_hip());
+      ds.field("mirror_tracking", &self.mirror_tracking());
       ds.finish()
   }
 }

--- a/protocol/typescript/src/solarxr-protocol/rpc/vmcoscsettings.ts
+++ b/protocol/typescript/src/solarxr-protocol/rpc/vmcoscsettings.ts
@@ -43,8 +43,13 @@ anchorHip():boolean {
   return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
 }
 
+mirrorTracking():boolean {
+  const offset = this.bb!.__offset(this.bb_pos, 10);
+  return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
+}
+
 static startVMCOSCSettings(builder:flatbuffers.Builder) {
-  builder.startObject(3);
+  builder.startObject(4);
 }
 
 static addOscSettings(builder:flatbuffers.Builder, oscSettingsOffset:flatbuffers.Offset) {
@@ -59,16 +64,21 @@ static addAnchorHip(builder:flatbuffers.Builder, anchorHip:boolean) {
   builder.addFieldInt8(2, +anchorHip, +false);
 }
 
+static addMirrorTracking(builder:flatbuffers.Builder, mirrorTracking:boolean) {
+  builder.addFieldInt8(3, +mirrorTracking, +false);
+}
+
 static endVMCOSCSettings(builder:flatbuffers.Builder):flatbuffers.Offset {
   const offset = builder.endObject();
   return offset;
 }
 
-static createVMCOSCSettings(builder:flatbuffers.Builder, oscSettingsOffset:flatbuffers.Offset, vrmJsonOffset:flatbuffers.Offset, anchorHip:boolean):flatbuffers.Offset {
+static createVMCOSCSettings(builder:flatbuffers.Builder, oscSettingsOffset:flatbuffers.Offset, vrmJsonOffset:flatbuffers.Offset, anchorHip:boolean, mirrorTracking:boolean):flatbuffers.Offset {
   VMCOSCSettings.startVMCOSCSettings(builder);
   VMCOSCSettings.addOscSettings(builder, oscSettingsOffset);
   VMCOSCSettings.addVrmJson(builder, vrmJsonOffset);
   VMCOSCSettings.addAnchorHip(builder, anchorHip);
+  VMCOSCSettings.addMirrorTracking(builder, mirrorTracking);
   return VMCOSCSettings.endVMCOSCSettings(builder);
 }
 
@@ -76,7 +86,8 @@ unpack(): VMCOSCSettingsT {
   return new VMCOSCSettingsT(
     (this.oscSettings() !== null ? this.oscSettings()!.unpack() : null),
     this.vrmJson(),
-    this.anchorHip()
+    this.anchorHip(),
+    this.mirrorTracking()
   );
 }
 
@@ -85,6 +96,7 @@ unpackTo(_o: VMCOSCSettingsT): void {
   _o.oscSettings = (this.oscSettings() !== null ? this.oscSettings()!.unpack() : null);
   _o.vrmJson = this.vrmJson();
   _o.anchorHip = this.anchorHip();
+  _o.mirrorTracking = this.mirrorTracking();
 }
 }
 
@@ -92,7 +104,8 @@ export class VMCOSCSettingsT implements flatbuffers.IGeneratedObject {
 constructor(
   public oscSettings: OSCSettingsT|null = null,
   public vrmJson: string|Uint8Array|null = null,
-  public anchorHip: boolean = false
+  public anchorHip: boolean = false,
+  public mirrorTracking: boolean = false
 ){}
 
 
@@ -103,7 +116,8 @@ pack(builder:flatbuffers.Builder): flatbuffers.Offset {
   return VMCOSCSettings.createVMCOSCSettings(builder,
     oscSettings,
     vrmJson,
-    this.anchorHip
+    this.anchorHip,
+    this.mirrorTracking
   );
 }
 }

--- a/schema/rpc.fbs
+++ b/schema/rpc.fbs
@@ -204,6 +204,7 @@ table VMCOSCSettings {
     osc_settings: OSCSettings;
     vrm_json: string;
     anchor_hip: bool;
+    mirror_tracking: bool;
 }
 
 /// OSC Settings that are used in *any* osc application.


### PR DESCRIPTION
This is a toggle used to mirror the tracking before sending it via VMC. It does not mirror the tracking inside the skeleton itself.