### PR TITLE
[Spine Yaw Compensation] Add enabled field to settings

### DIFF
--- a/protocol/cpp/include/solarxr_protocol/generated/all_generated.h
+++ b/protocol/cpp/include/solarxr_protocol/generated/all_generated.h
@@ -6720,13 +6720,18 @@ inline flatbuffers::Offset<ResetsSettings> CreateResetsSettings(
 struct YawCorrectionSettings FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef YawCorrectionSettingsBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_AMOUNTINDEGPERSEC = 4
+    VT_ENABLED = 4,
+    VT_AMOUNTINDEGPERSEC = 6
   };
+  bool enabled() const {
+    return GetField<uint8_t>(VT_ENABLED, 0) != 0;
+  }
   float amountInDegPerSec() const {
     return GetField<float>(VT_AMOUNTINDEGPERSEC, 0.0f);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
+           VerifyField<uint8_t>(verifier, VT_ENABLED, 1) &&
            VerifyField<float>(verifier, VT_AMOUNTINDEGPERSEC, 4) &&
            verifier.EndTable();
   }
@@ -6736,6 +6741,9 @@ struct YawCorrectionSettingsBuilder {
   typedef YawCorrectionSettings Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
+  void add_enabled(bool enabled) {
+    fbb_.AddElement<uint8_t>(YawCorrectionSettings::VT_ENABLED, static_cast<uint8_t>(enabled), 0);
+  }
   void add_amountInDegPerSec(float amountInDegPerSec) {
     fbb_.AddElement<float>(YawCorrectionSettings::VT_AMOUNTINDEGPERSEC, amountInDegPerSec, 0.0f);
   }
@@ -6752,9 +6760,11 @@ struct YawCorrectionSettingsBuilder {
 
 inline flatbuffers::Offset<YawCorrectionSettings> CreateYawCorrectionSettings(
     flatbuffers::FlatBufferBuilder &_fbb,
+    bool enabled = false,
     float amountInDegPerSec = 0.0f) {
   YawCorrectionSettingsBuilder builder_(_fbb);
   builder_.add_amountInDegPerSec(amountInDegPerSec);
+  builder_.add_enabled(enabled);
   return builder_.Finish();
 }
 

--- a/protocol/java/src/solarxr_protocol/rpc/YawCorrectionSettings.java
+++ b/protocol/java/src/solarxr_protocol/rpc/YawCorrectionSettings.java
@@ -15,17 +15,21 @@ public final class YawCorrectionSettings extends Table {
   public void __init(int _i, ByteBuffer _bb) { __reset(_i, _bb); }
   public YawCorrectionSettings __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public float amountInDegPerSec() { int o = __offset(4); return o != 0 ? bb.getFloat(o + bb_pos) : 0.0f; }
+  public boolean enabled() { int o = __offset(4); return o != 0 ? 0!=bb.get(o + bb_pos) : false; }
+  public float amountInDegPerSec() { int o = __offset(6); return o != 0 ? bb.getFloat(o + bb_pos) : 0.0f; }
 
   public static int createYawCorrectionSettings(FlatBufferBuilder builder,
+      boolean enabled,
       float amountInDegPerSec) {
-    builder.startTable(1);
+    builder.startTable(2);
     YawCorrectionSettings.addAmountInDegPerSec(builder, amountInDegPerSec);
+    YawCorrectionSettings.addEnabled(builder, enabled);
     return YawCorrectionSettings.endYawCorrectionSettings(builder);
   }
 
-  public static void startYawCorrectionSettings(FlatBufferBuilder builder) { builder.startTable(1); }
-  public static void addAmountInDegPerSec(FlatBufferBuilder builder, float amountInDegPerSec) { builder.addFloat(0, amountInDegPerSec, 0.0f); }
+  public static void startYawCorrectionSettings(FlatBufferBuilder builder) { builder.startTable(2); }
+  public static void addEnabled(FlatBufferBuilder builder, boolean enabled) { builder.addBoolean(0, enabled, false); }
+  public static void addAmountInDegPerSec(FlatBufferBuilder builder, float amountInDegPerSec) { builder.addFloat(1, amountInDegPerSec, 0.0f); }
   public static int endYawCorrectionSettings(FlatBufferBuilder builder) {
     int o = builder.endTable();
     return o;
@@ -43,6 +47,8 @@ public final class YawCorrectionSettings extends Table {
     return _o;
   }
   public void unpackTo(YawCorrectionSettingsT _o) {
+    boolean _oEnabled = enabled();
+    _o.setEnabled(_oEnabled);
     float _oAmountInDegPerSec = amountInDegPerSec();
     _o.setAmountInDegPerSec(_oAmountInDegPerSec);
   }
@@ -50,6 +56,7 @@ public final class YawCorrectionSettings extends Table {
     if (_o == null) return 0;
     return createYawCorrectionSettings(
       builder,
+      _o.getEnabled(),
       _o.getAmountInDegPerSec());
   }
 }

--- a/protocol/java/src/solarxr_protocol/rpc/YawCorrectionSettingsT.java
+++ b/protocol/java/src/solarxr_protocol/rpc/YawCorrectionSettingsT.java
@@ -8,7 +8,12 @@ import java.util.*;
 import com.google.flatbuffers.*;
 
 public class YawCorrectionSettingsT {
+  private boolean enabled;
   private float amountInDegPerSec;
+
+  public boolean getEnabled() { return enabled; }
+
+  public void setEnabled(boolean enabled) { this.enabled = enabled; }
 
   public float getAmountInDegPerSec() { return amountInDegPerSec; }
 
@@ -16,6 +21,7 @@ public class YawCorrectionSettingsT {
 
 
   public YawCorrectionSettingsT() {
+    this.enabled = false;
     this.amountInDegPerSec = 0.0f;
   }
 }

--- a/protocol/kotlin/src/solarxr_protocol/rpc/YawCorrectionSettings.kt
+++ b/protocol/kotlin/src/solarxr_protocol/rpc/YawCorrectionSettings.kt
@@ -16,9 +16,14 @@ class YawCorrectionSettings : Table() {
         __init(_i, _bb)
         return this
     }
-    val amountInDegPerSec : Float
+    val enabled : Boolean
         get() {
             val o = __offset(4)
+            return if(o != 0) 0.toByte() != bb.get(o + bb_pos) else false
+        }
+    val amountInDegPerSec : Float
+        get() {
+            val o = __offset(6)
             return if(o != 0) bb.getFloat(o + bb_pos) else 0.0f
         }
     companion object {
@@ -32,15 +37,18 @@ class YawCorrectionSettings : Table() {
             return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb))
         }
         @JvmStatic
-        fun createYawCorrectionSettings(builder: FlatBufferBuilder, amountInDegPerSec: Float) : Int {
-            builder.startTable(1)
+        fun createYawCorrectionSettings(builder: FlatBufferBuilder, enabled: Boolean, amountInDegPerSec: Float) : Int {
+            builder.startTable(2)
             addAmountInDegPerSec(builder, amountInDegPerSec)
+            addEnabled(builder, enabled)
             return endYawCorrectionSettings(builder)
         }
         @JvmStatic
-        fun startYawCorrectionSettings(builder: FlatBufferBuilder) = builder.startTable(1)
+        fun startYawCorrectionSettings(builder: FlatBufferBuilder) = builder.startTable(2)
         @JvmStatic
-        fun addAmountInDegPerSec(builder: FlatBufferBuilder, amountInDegPerSec: Float) = builder.addFloat(0, amountInDegPerSec, 0.0)
+        fun addEnabled(builder: FlatBufferBuilder, enabled: Boolean) = builder.addBoolean(0, enabled, false)
+        @JvmStatic
+        fun addAmountInDegPerSec(builder: FlatBufferBuilder, amountInDegPerSec: Float) = builder.addFloat(1, amountInDegPerSec, 0.0)
         @JvmStatic
         fun endYawCorrectionSettings(builder: FlatBufferBuilder) : Int {
             val o = builder.endTable()

--- a/protocol/rust/src/generated/solarxr_protocol/rpc/yaw_correction_settings_generated.rs
+++ b/protocol/rust/src/generated/solarxr_protocol/rpc/yaw_correction_settings_generated.rs
@@ -25,7 +25,8 @@ impl<'a> flatbuffers::Follow<'a> for YawCorrectionSettings<'a> {
 }
 
 impl<'a> YawCorrectionSettings<'a> {
-  pub const VT_AMOUNTINDEGPERSEC: flatbuffers::VOffsetT = 4;
+  pub const VT_ENABLED: flatbuffers::VOffsetT = 4;
+  pub const VT_AMOUNTINDEGPERSEC: flatbuffers::VOffsetT = 6;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -38,10 +39,18 @@ impl<'a> YawCorrectionSettings<'a> {
   ) -> flatbuffers::WIPOffset<YawCorrectionSettings<'bldr>> {
     let mut builder = YawCorrectionSettingsBuilder::new(_fbb);
     builder.add_amountInDegPerSec(args.amountInDegPerSec);
+    builder.add_enabled(args.enabled);
     builder.finish()
   }
 
 
+  #[inline]
+  pub fn enabled(&self) -> bool {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<bool>(YawCorrectionSettings::VT_ENABLED, Some(false)).unwrap()}
+  }
   #[inline]
   pub fn amountInDegPerSec(&self) -> f32 {
     // Safety:
@@ -58,18 +67,21 @@ impl flatbuffers::Verifiable for YawCorrectionSettings<'_> {
   ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
+     .visit_field::<bool>("enabled", Self::VT_ENABLED, false)?
      .visit_field::<f32>("amountInDegPerSec", Self::VT_AMOUNTINDEGPERSEC, false)?
      .finish();
     Ok(())
   }
 }
 pub struct YawCorrectionSettingsArgs {
+    pub enabled: bool,
     pub amountInDegPerSec: f32,
 }
 impl<'a> Default for YawCorrectionSettingsArgs {
   #[inline]
   fn default() -> Self {
     YawCorrectionSettingsArgs {
+      enabled: false,
       amountInDegPerSec: 0.0,
     }
   }
@@ -80,6 +92,10 @@ pub struct YawCorrectionSettingsBuilder<'a: 'b, 'b> {
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> YawCorrectionSettingsBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_enabled(&mut self, enabled: bool) {
+    self.fbb_.push_slot::<bool>(YawCorrectionSettings::VT_ENABLED, enabled, false);
+  }
   #[inline]
   pub fn add_amountInDegPerSec(&mut self, amountInDegPerSec: f32) {
     self.fbb_.push_slot::<f32>(YawCorrectionSettings::VT_AMOUNTINDEGPERSEC, amountInDegPerSec, 0.0);
@@ -102,6 +118,7 @@ impl<'a: 'b, 'b> YawCorrectionSettingsBuilder<'a, 'b> {
 impl core::fmt::Debug for YawCorrectionSettings<'_> {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
     let mut ds = f.debug_struct("YawCorrectionSettings");
+      ds.field("enabled", &self.enabled());
       ds.field("amountInDegPerSec", &self.amountInDegPerSec());
       ds.finish()
   }

--- a/protocol/typescript/src/solarxr-protocol/rpc/yaw-correction-settings.ts
+++ b/protocol/typescript/src/solarxr-protocol/rpc/yaw-correction-settings.ts
@@ -22,17 +22,26 @@ static getSizePrefixedRootAsYawCorrectionSettings(bb:flatbuffers.ByteBuffer, obj
   return (obj || new YawCorrectionSettings()).__init(bb.readInt32(bb.position()) + bb.position(), bb);
 }
 
-amountInDegPerSec():number {
+enabled():boolean {
   const offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
+}
+
+amountInDegPerSec():number {
+  const offset = this.bb!.__offset(this.bb_pos, 6);
   return offset ? this.bb!.readFloat32(this.bb_pos + offset) : 0.0;
 }
 
 static startYawCorrectionSettings(builder:flatbuffers.Builder) {
-  builder.startObject(1);
+  builder.startObject(2);
+}
+
+static addEnabled(builder:flatbuffers.Builder, enabled:boolean) {
+  builder.addFieldInt8(0, +enabled, +false);
 }
 
 static addAmountInDegPerSec(builder:flatbuffers.Builder, amountInDegPerSec:number) {
-  builder.addFieldFloat32(0, amountInDegPerSec, 0.0);
+  builder.addFieldFloat32(1, amountInDegPerSec, 0.0);
 }
 
 static endYawCorrectionSettings(builder:flatbuffers.Builder):flatbuffers.Offset {
@@ -40,32 +49,37 @@ static endYawCorrectionSettings(builder:flatbuffers.Builder):flatbuffers.Offset 
   return offset;
 }
 
-static createYawCorrectionSettings(builder:flatbuffers.Builder, amountInDegPerSec:number):flatbuffers.Offset {
+static createYawCorrectionSettings(builder:flatbuffers.Builder, enabled:boolean, amountInDegPerSec:number):flatbuffers.Offset {
   YawCorrectionSettings.startYawCorrectionSettings(builder);
+  YawCorrectionSettings.addEnabled(builder, enabled);
   YawCorrectionSettings.addAmountInDegPerSec(builder, amountInDegPerSec);
   return YawCorrectionSettings.endYawCorrectionSettings(builder);
 }
 
 unpack(): YawCorrectionSettingsT {
   return new YawCorrectionSettingsT(
+    this.enabled(),
     this.amountInDegPerSec()
   );
 }
 
 
 unpackTo(_o: YawCorrectionSettingsT): void {
+  _o.enabled = this.enabled();
   _o.amountInDegPerSec = this.amountInDegPerSec();
 }
 }
 
 export class YawCorrectionSettingsT implements flatbuffers.IGeneratedObject {
 constructor(
+  public enabled: boolean = false,
   public amountInDegPerSec: number = 0.0
 ){}
 
 
 pack(builder:flatbuffers.Builder): flatbuffers.Offset {
   return YawCorrectionSettings.createYawCorrectionSettings(builder,
+    this.enabled,
     this.amountInDegPerSec
   );
 }

--- a/schema/rpc.fbs
+++ b/schema/rpc.fbs
@@ -271,6 +271,7 @@ table ResetsSettings {
 }
 
 table YawCorrectionSettings {
+    enabled: bool;
     amountInDegPerSec: float32;
 }
 


### PR DESCRIPTION
Adds `enabled` to `YawCorrectionSettings` to address https://github.com/SlimeVR/SlimeVR-Server/pull/1243#discussion_r1847440941

I added `enabled` to the start of the table because the table is not being used yet. This changes the ID of the other field. Let me know if I shouldn't do this.